### PR TITLE
The space Availability APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@protobuf-ts/plugin": "^2.6.0",
-    "@windingtree/stays-models": "^1.0.1",
+    "@windingtree/stays-models": "^2.0.0",
     "@windingtree/videre-sdk": "^0.5.0",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
@@ -85,6 +85,7 @@
     "@types/node": "^17.0.38",
     "@types/response-time": "^2.3.5",
     "@types/swagger-ui-express": "^4.1.3",
+    "@types/luxon": "^2.3.2",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "@windingtree/videre-contracts": "^0.2.0-alpha.1",

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -11,10 +11,6 @@ export class FacilityController {
     try {
       const { facilityId, spaceId, date } = req.params;
 
-      if (!DateTime.fromSQL(date).isValid) {
-        throw ApiError.BadRequest('Invalid availability date format');
-      }
-
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
       const numSpaces = await repository.getSpaceAvailabilityNumSpaces(date as AvailabilityDate);
 
@@ -37,7 +33,7 @@ export class FacilityController {
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
       await repository.createAvailabilityByDate(
         date as AvailabilityDate,
-        numSpaces
+        Number(numSpaces)
       );
 
       return res.json({ success: true });
@@ -53,7 +49,7 @@ export class FacilityController {
       const { numSpaces } = req.body;
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      await repository.createDefaultAvailability(numSpaces);
+      await repository.createDefaultAvailability(Number(numSpaces));
 
       return res.json({ success: true });
     } catch (e) {

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -5,23 +5,32 @@ import ApiError from '../exceptions/ApiError';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
 
 export class FacilityController {
-
   // Returns availability of the space
-  getSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+  getSpaceAvailability = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
     try {
       const { facilityId, spaceId, date } = req.params;
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      const numSpaces = await repository.getSpaceAvailabilityNumSpaces(date as AvailabilityDate);
+      const numSpaces = await repository.getSpaceAvailabilityNumSpaces(
+        date as AvailabilityDate
+      );
 
       return res.json({ numSpaces });
     } catch (e) {
       next(e);
     }
-  }
+  };
 
   // Adds availability of the space by date
-  createSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+  createSpaceAvailability = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
     try {
       const { facilityId, spaceId, date } = req.params;
       const { numSpaces } = req.body;
@@ -40,10 +49,14 @@ export class FacilityController {
     } catch (e) {
       next(e);
     }
-  }
+  };
 
   // Adds/updates `default` availability of the space
-  createDefaultSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+  createDefaultSpaceAvailability = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
     try {
       const { facilityId, spaceId } = req.params;
       const { numSpaces } = req.body;
@@ -55,7 +68,7 @@ export class FacilityController {
     } catch (e) {
       next(e);
     }
-  }
+  };
 }
 
 export default new FacilityController();

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { AvailabilityDate } from '../services/DBService';
+import { DateTime } from 'luxon';
+import ApiError from '../exceptions/ApiError';
+import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
+
+export class FacilityController {
+
+  // Returns availability of the space
+  getSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { facilityId, spaceId, date } = req.params;
+
+      if (!DateTime.fromSQL(date).isValid) {
+        throw ApiError.BadRequest('Invalid availability date format');
+      }
+
+      const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
+      const numSpaces = await repository.getSpaceAvailabilityNumSpaces(date as AvailabilityDate);
+
+      return res.json({ numSpaces });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  // Adds availability of the space by date
+  createSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { facilityId, spaceId, date } = req.params;
+      const { numSpaces } = req.body;
+
+      if (!DateTime.fromSQL(date).isValid) {
+        throw ApiError.BadRequest('Invalid availability date format');
+      }
+
+      const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
+      await repository.createAvailabilityByDate(
+        date as AvailabilityDate,
+        numSpaces
+      );
+
+      return res.json({ success: true });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  // Adds/updates `default` availability of the space
+  createDefaultSpaceAvailability = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { facilityId, spaceId } = req.params;
+      const { numSpaces } = req.body;
+
+      const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
+      await repository.createDefaultAvailability(numSpaces);
+
+      return res.json({ success: true });
+    } catch (e) {
+      next(e);
+    }
+  }
+}
+
+export default new FacilityController();

--- a/src/controllers/StorageController.ts
+++ b/src/controllers/StorageController.ts
@@ -11,7 +11,7 @@ import walletService from '../services/WalletService';
 import { web3StorageKey, typedDataDomain } from '../config';
 import { walletAccountsIndexes } from '../types';
 import { Facility, Item, ItemType, Space } from '../proto/facility';
-import facilitiesService from '../services/FacilitiesService';
+import facilityService from '../services/FacilityService';
 import { FacilitySpaceLevelValues } from 'src/services/DBService';
 const { readFile } = promises;
 
@@ -67,7 +67,7 @@ export class StorageController {
       );
 
       // Extract ans save/update facility from metadata
-      await facilitiesService.setFacilityDbKeys(serviceProviderId, [
+      await facilityService.setFacilityDbKeys(serviceProviderId, [
         [
           'metadata',
           Facility.fromBinary(serviceProviderData.payload) as Facility
@@ -95,7 +95,7 @@ export class StorageController {
       // Add/update spaces to DB
       await Promise.all(
         Object.entries(spaces).map(([itemId, entries]) =>
-          facilitiesService.setItemDbKeys(
+          facilityService.setItemDbKeys(
             serviceProviderId,
             'spaces',
             itemId,
@@ -107,7 +107,7 @@ export class StorageController {
       // Add/update other items to DB
       await Promise.all(
         Object.entries(otherItems).map(([itemId, entries]) =>
-          facilitiesService.setItemDbKeys(
+          facilityService.setItemDbKeys(
             serviceProviderId,
             'otherItems',
             itemId,

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -13,10 +13,9 @@ export class FacilityRepository {
 
   public async getFacilityIds(): Promise<string[]> {
     try {
-      return await this.db.get<string, string[]>(
-        'facilities',
-        { valueEncoding: 'json' }
-      );
+      return await this.db.get<string, string[]>('facilities', {
+        valueEncoding: 'json'
+      });
     } catch (e) {
       if (e.status !== 404) {
         throw e;
@@ -25,7 +24,10 @@ export class FacilityRepository {
     return [];
   }
 
-  public async createFacility(facilityId: string, facility: Facility): Promise<void> {
+  public async createFacility(
+    facilityId: string,
+    facility: Facility
+  ): Promise<void> {
     const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
 
     await facilitySublevel.put('metadata', facility);

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -1,17 +1,32 @@
-import DBService, { AvailabilityDate, AvailabilityItemKey, FacilityItemValues, LevelDefaultTyping } from '../services/DBService';
+import DBService, {
+  AvailabilityDate,
+  AvailabilityItemKey,
+  FacilityItemValues,
+  LevelDefaultTyping
+} from '../services/DBService';
 import { AbstractLevel, AbstractSublevel } from 'abstract-level';
 import { Availability } from '../proto/lpms';
 
 export class SpaceAvailabilityRepository {
   private dbService: DBService;
-  private availableDB: AbstractSublevel<AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>, LevelDefaultTyping, AvailabilityItemKey, Availability>;
+  private availableDB: AbstractSublevel<
+    AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>,
+    LevelDefaultTyping,
+    AvailabilityItemKey,
+    Availability
+  >;
 
   constructor(facilityId: string, spaceId: string) {
     this.dbService = DBService.getInstance();
-    this.availableDB = this.dbService.getSpaceAvailabilityDB(facilityId, spaceId);
+    this.availableDB = this.dbService.getSpaceAvailabilityDB(
+      facilityId,
+      spaceId
+    );
   }
 
-  public async getSpaceAvailabilityNumSpaces(key: AvailabilityItemKey): Promise<number> {
+  public async getSpaceAvailabilityNumSpaces(
+    key: AvailabilityItemKey
+  ): Promise<number> {
     try {
       const availability: Availability = await this.availableDB.get(key);
       return availability.numSpaces;

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -1,17 +1,17 @@
-import DBService, { DateType, FacilityItemValues, LevelDefaultTyping } from '../services/DBService';
+import DBService, { AvailabilityDate, AvailabilityItemKey, FacilityItemValues, LevelDefaultTyping } from '../services/DBService';
 import { AbstractLevel, AbstractSublevel } from 'abstract-level';
 import { Availability } from '../proto/lpms';
 
 export class SpaceAvailabilityRepository {
   private dbService: DBService;
-  private availableDB: AbstractSublevel<AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>, LevelDefaultTyping, "default" | DateType, Availability>;
+  private availableDB: AbstractSublevel<AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>, LevelDefaultTyping, AvailabilityItemKey, Availability>;
 
-  constructor(facilityId, spaceId) {
+  constructor(facilityId: string, spaceId: string) {
     this.dbService = DBService.getInstance();
     this.availableDB = this.dbService.getSpaceAvailabilityDB(facilityId, spaceId);
   }
 
-  public async getSpaceAvailabilityNumSpaces(key): Promise<number> {
+  public async getSpaceAvailabilityNumSpaces(key: AvailabilityItemKey): Promise<number> {
     try {
       const availability: Availability = await this.availableDB.get(key);
       return availability.numSpaces;
@@ -24,11 +24,22 @@ export class SpaceAvailabilityRepository {
     return 0;
   }
 
-  public async createAvailabilityByDate(key: DateType): Promise<void> {
+  public async createDefaultAvailability(numSpaces: number): Promise<void> {
+    const availability: Availability = {
+      numSpaces
+    };
+
+    await this.availableDB.put('default', availability);
+  }
+
+  public async createAvailabilityByDate(
+    key: AvailabilityDate,
+    numSpaces = 1
+  ): Promise<void> {
     const count = await this.getSpaceAvailabilityNumSpaces(key);
 
     const availability: Availability = {
-      numSpaces: count + 1
+      numSpaces: count + numSpaces
     };
 
     await this.availableDB.put(key, availability);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -430,7 +430,7 @@ router.get(
 
 /**
  * @swagger
- * /facility/{facilityId}/space/{spaceId}/availability/default:
+ * /facility/{facilityId}/space/{spaceId}/availability:
  *   post:
  *     security:
  *       - bearerAuth: []
@@ -479,7 +479,7 @@ router.get(
  *         description: Some server error
  */
  router.post(
-  '/facility/:facilityId/space/:spaceId/availability/default',
+  '/facility/:facilityId/space/:spaceId/availability',
   authMiddleware,
   facilityController.createDefaultSpaceAvailability
 );

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -376,16 +376,16 @@ router.get(
  *     tags: [Facility service]
  *     requestBody:
  *       required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 numSpaces:
- *                   type: number
- *                   description: Number of available spaces to add
- *               required:
- *                 - numSpaces
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               numSpaces:
+ *                 type: number
+ *                 description: Number of available spaces to add
+ *             required:
+ *               - numSpaces
  *     parameters:
  *       - in: path
  *         name: facilityId
@@ -438,16 +438,16 @@ router.get(
  *     tags: [Facility service]
  *     requestBody:
  *       required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 numSpaces:
- *                   type: number
- *                   description: Number of available spaces to add
- *               required:
- *                 - numSpaces
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               numSpaces:
+ *                 type: number
+ *                 description: Number of available spaces to add
+ *             required:
+ *               - numSpaces
  *     parameters:
  *       - in: path
  *         name: facilityId

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -361,9 +361,9 @@ export default router;
  *         description: Some server error
  */
 router.get(
-   '/facility/:facilityId/space/:spaceId/availability/:date',
-   authMiddleware,
-   facilityController.getSpaceAvailability
+  '/facility/:facilityId/space/:spaceId/availability/:date',
+  authMiddleware,
+  facilityController.getSpaceAvailability
 );
 
 /**
@@ -422,7 +422,7 @@ router.get(
  *       500:
  *         description: Some server error
  */
- router.post(
+router.post(
   '/facility/:facilityId/space/:spaceId/availability/:date',
   authMiddleware,
   facilityController.createSpaceAvailability
@@ -478,7 +478,7 @@ router.get(
  *       500:
  *         description: Some server error
  */
- router.post(
+router.post(
   '/facility/:facilityId/space/:spaceId/availability',
   authMiddleware,
   facilityController.createDefaultSpaceAvailability

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -115,9 +115,9 @@ export default class DBService {
   }
 
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<AvailabilityItemKey, Availability>(
-      'availability',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<
+      AvailabilityItemKey,
+      Availability
+    >('availability', { valueEncoding: 'json' });
   }
 }

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -28,7 +28,8 @@ export type FacilityLevelValues = Facility | string[];
 export type FacilitySpaceLevelValues = Item | Space;
 export type FacilityItemType = 'spaces' | 'otherItems';
 export type FacilityItemValues = Item | FacilitySpaceLevelValues;
-export type DateType = `${number}-${number}-${number}`
+export type AvailabilityDate = `${number}-${number}-${number}`;
+export type AvailabilityItemKey = 'default' | AvailabilityDate;
 
 export default class DBService {
   protected db: DBLevel;
@@ -114,7 +115,7 @@ export default class DBService {
   }
 
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<'default' | DateType, Availability>(
+    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<AvailabilityItemKey, Availability>(
       'availability',
       { valueEncoding: 'json' }
     );

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -6,7 +6,7 @@ import DBService, {
   FacilitySpaceLevelValues
 } from './DBService';
 
-export class FacilitiesService {
+export class FacilityService {
   private dbService: DBService;
   private db: Level<string, string | string[]>;
 
@@ -126,4 +126,4 @@ export class FacilitiesService {
   }
 }
 
-export default new FacilitiesService();
+export default new FacilityService();

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { Ask } from 'src/proto/ask';
 import { Space } from '../proto/facility';
-import DBService from './DBService';
+import DBService, { AvailabilityDate } from './DBService';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
 
 export default class SpaceSearchService {
@@ -93,7 +93,9 @@ export default class SpaceSearchService {
 
     while (from <= to) {
       try {
-        const dailyBooks = await availabilityRepository.getSpaceAvailabilityNumSpaces(from.toFormat('yyyy-MM-dd'));
+        const dailyBooks = await availabilityRepository.getSpaceAvailabilityNumSpaces(
+          from.toFormat('yyyy-MM-dd') as AvailabilityDate
+        );
 
         if (defaultAvailable - dailyBooks < spacesRequired) {
           return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,6 +1387,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/luxon@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.3.2.tgz#8a3f2cdd4858ce698b56cd8597d9243b8e9d3c65"
+  integrity sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -1634,10 +1639,10 @@
   resolved "https://registry.yarnpkg.com/@web3-storage/parse-link-header/-/parse-link-header-3.1.0.tgz#4562724987649dd6d3e07c87be1826804d212ef7"
   integrity sha512-K1undnK70vLLauqdE8bq/l98isTF2FDhcP0UPpXVSjkSWe3xhAn5eRXk5jfA1E5ycNm84Ws/rQFUD7ue11nciw==
 
-"@windingtree/stays-models@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@windingtree/stays-models/-/stays-models-1.0.1.tgz#9daed75df5468615efd7afbcd60e53b1fac49ec3"
-  integrity sha512-c6KifDDZsdbk6l+gNstAkLuQT4KKCZkUPx01SorUFDPMnfVstgpZV+QQJeT08mK1f73BevVL0p45HE/sgDYMgQ==
+"@windingtree/stays-models@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@windingtree/stays-models/-/stays-models-2.0.0.tgz#5399baca2618cc3bda65361bff179a5d3e162f5b"
+  integrity sha512-PhO/eX3FireIN3tcQFMQBJ6b+Z4fgGXtrmvAbBqKj2Ouasf0FB/+yQmyFy8jl2cFJpUF1H7dgpspfsFaJaBHJA==
   dependencies:
     "@protobuf-ts/runtime" "^2.6.0"
     zlib "^1.0.5"


### PR DESCRIPTION
This PR adds the following API endpoints:

- GET: `/facility/{facilityId}/space/{spaceId}/availability/{date | 'default'}`: returns actual availability as `Availability` object
- POST: `/facility/{facilityId}/space/{spaceId}/availability`: creates/updates the 'default' space availability
- POST: `/facility/{facilityId}/space/{spaceId}/availability/{date}`: adds availability at the `date` (formatted as `yyyy-DD-MM`)

Both `POST` endpoints accepting as `requestBody` a valid `Availability` object.

NOTE: 
- when creating a `default` availability of type its value will be **overwritten** by the new value
- when creating availability for `date` its value will be **incremented** 