### PR TITLE
Missing otherItems rates

### DIFF
--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -102,11 +102,11 @@ Notes: This meets the requirement (2)
 Parent level: `facilityId` (dynamic)
 Level: `spaceId` (dynamic)
 
-Key: `metadata_generic`
+Key: `metadata`
 Value: `videre.stays.lpms.facility.Item`
 Description: Contains generic data for each item (name, photos etc)
 
-Key: `metadata`
+Key: `metadata_impl`
 Value: `videre.stays.lpms.facility.Space`
 Description: Contains specific metadata for Spaces (views, sleeping arrangements etc).
 
@@ -185,11 +185,24 @@ Notes: This meets the requirement (4)
 #### otherItems
 
 Parent level: `facilityId` (dynamic)
-Level: `otherItems`
+Level: `otherItemdId` (dynamic)
 
-Key: `itemId` (dynamic)
+Key: `metadata` (dynamic)
 Value: `videre.stays.lpms.facility.Item`
 Description: Contains generic data for the item (name, photos, etc)
+
+##### rates
+
+Parent level: `facilityId.otherItemdId` (dynamic)
+Level: `rates`
+
+Key: `default`
+Value: `videre.stays.lpms.Rates`
+Description: Contains the `Rates` message protobuf describing the rate for this item.
+
+Key: `YYYY-MM-DD` (dynamic)
+Value: `videre.stays.lpms.Rates`
+Description: Contains the `Rates` message protobuf for a per-day override of rates.
 
 # CRUD
 

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -41,7 +41,7 @@ export class FacilityController {
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
       await repository.setAvailabilityByDate(date as FormattedDate, {
-        numSpaces: numSpaces
+        numSpaces: Number(numSpaces)
       });
 
       return res.json({ success: true });
@@ -61,7 +61,7 @@ export class FacilityController {
       const { numSpaces } = req.body;
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      await repository.setAvailabilityDefault({ numSpaces: numSpaces });
+      await repository.setAvailabilityDefault({ numSpaces: Number(numSpaces) });
 
       return res.json({ success: true });
     } catch (e) {

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -40,12 +40,9 @@ export class FacilityController {
       }
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      await repository.setAvailabilityByDate(
-        date as FormattedDate,
-        {
-          numSpaces: numSpaces
-        }
-      );
+      await repository.setAvailabilityByDate(date as FormattedDate, {
+        numSpaces: numSpaces
+      });
 
       return res.json({ success: true });
     } catch (e) {

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -15,7 +15,7 @@ export class FacilityController {
       const { facilityId, spaceId, date } = req.params;
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      const numSpaces = await repository.getSpaceAvailabilityNumSpaces(
+      const numSpaces = await repository.getSpaceAvailability(
         date as AvailabilityDate
       );
 
@@ -40,9 +40,11 @@ export class FacilityController {
       }
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      await repository.createAvailabilityByDate(
+      await repository.setAvailabilityByDate(
         date as AvailabilityDate,
-        Number(numSpaces)
+        {
+          numSpaces: numSpaces
+        }
       );
 
       return res.json({ success: true });
@@ -62,7 +64,7 @@ export class FacilityController {
       const { numSpaces } = req.body;
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
-      await repository.createDefaultAvailability(Number(numSpaces));
+      await repository.setAvailabilityDefault({ numSpaces: numSpaces });
 
       return res.json({ success: true });
     } catch (e) {

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import type { AvailabilityDate } from '../services/DBService';
+import type { FormattedDate } from '../services/DBService';
 import { DateTime } from 'luxon';
 import ApiError from '../exceptions/ApiError';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
@@ -16,7 +16,7 @@ export class FacilityController {
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
       const numSpaces = await repository.getSpaceAvailability(
-        date as AvailabilityDate
+        date as FormattedDate
       );
 
       return res.json({ numSpaces });
@@ -41,7 +41,7 @@ export class FacilityController {
 
       const repository = new SpaceAvailabilityRepository(facilityId, spaceId);
       await repository.setAvailabilityByDate(
-        date as AvailabilityDate,
+        date as FormattedDate,
         {
           numSpaces: numSpaces
         }

--- a/src/controllers/StorageController.ts
+++ b/src/controllers/StorageController.ts
@@ -12,7 +12,7 @@ import { web3StorageKey, typedDataDomain } from '../config';
 import { walletAccountsIndexes } from '../types';
 import { Facility, Item, ItemType, Space } from '../proto/facility';
 import facilityService from '../services/FacilityService';
-import { FacilitySpaceLevelValues } from 'src/services/DBService';
+import { FacilitySpaceValues } from 'src/services/DBService';
 const { readFile } = promises;
 
 export class StorageController {
@@ -75,7 +75,7 @@ export class StorageController {
       ]);
 
       // Extract spaces from metadata
-      const spaces: Record<string, [string, FacilitySpaceLevelValues][]> = {};
+      const spaces: Record<string, [string, FacilitySpaceValues][]> = {};
       const otherItems: Record<string, [string, Item][]> = {};
 
       for (const item of serviceProviderData.items) {

--- a/src/middlewares/AuthMiddleware.ts
+++ b/src/middlewares/AuthMiddleware.ts
@@ -1,6 +1,7 @@
 import ApiError from '../exceptions/ApiError';
 import tokenService from '../services/TokenService';
 import userService from '../services/UserService';
+import userRepository from '../repositories/UserRepository';
 import { UserDTO } from '../types';
 
 export default async (req, res, next) => {
@@ -21,13 +22,13 @@ export default async (req, res, next) => {
       return next(ApiError.UnauthorizedError());
     }
 
-    const userExists = await userService.getUserIdByLogin(userData.login);
+    const userExists = await userRepository.getUserIdByLogin(userData.login);
 
     if (!userExists) {
       return next(ApiError.UnauthorizedError());
     }
 
-    const user = await userService.getUserById(userData.id);
+    const user = await userRepository.getUserById(userData.id);
     req.user = userService.getUserDTO(user);
     next();
   } catch (e) {

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -1,6 +1,6 @@
-import DBService from '../services/DBService';
+import DBService, { FacilityItemType, FacilityLevelValues, FacilitySpaceLevelValues } from '../services/DBService';
 import { Level } from 'level';
-import { Facility } from '../proto/facility';
+import { Item } from '../proto/facility';
 
 export class FacilityRepository {
   private dbService: DBService;
@@ -24,18 +24,7 @@ export class FacilityRepository {
     return [];
   }
 
-  public async createFacility(
-    facilityId: string,
-    facility: Facility
-  ): Promise<void> {
-    const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
-
-    await facilitySublevel.put('metadata', facility);
-
-    await this.createFacilityIndex(facilityId);
-  }
-
-  private async createFacilityIndex(facilityId: string) {
+  public async createFacilityIndex(facilityId: string) {
     const facilitiesIds = await this.getFacilityIds();
 
     if (facilitiesIds.length > 0) {
@@ -46,4 +35,99 @@ export class FacilityRepository {
       await this.db.put('facilities', [facilityId]);
     }
   }
+
+  public async getItemIds(
+    facilityId: string,
+    itemType: FacilityItemType
+  ): Promise<string[]> {
+    try {
+      const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
+      return await facilitySublevel.get<string, string[]>(itemType, {
+        valueEncoding: 'json'
+      });
+    } catch (e) {
+      if (e.status !== 404) {
+        throw e;
+      }
+    }
+    return [];
+  }
+
+  public async createFacilityItem(
+    facilityId: string,
+    key: string,
+    value: FacilityLevelValues
+  ): Promise<void> {
+    const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
+
+    await facilitySublevel.put(key, value);
+  }
+
+  public async getFacilityDbKey(
+    facilityId: string,
+    key: string
+  ): Promise<FacilityLevelValues> {
+    try {
+      return await this.dbService.getFacilitySublevelDB(facilityId).get(key);
+    } catch (e) {
+      if (e.status === 404) {
+        throw new Error(`Unable to get "${key}" of facility "${facilityId}"`);
+      }
+      throw e;
+    }
+  }
+
+  public async getSpaceDbKey(
+    facilityId: string,
+    spaceId: string,
+    key: string
+  ): Promise<FacilitySpaceLevelValues> {
+    try {
+      return await this.dbService
+        .getFacilityItemDB(facilityId, 'spaces', spaceId)
+        .get(key);
+    } catch (e) {
+      if (e.status === 404) {
+        throw new Error(
+          `Unable to get "${key}" of space "${spaceId}" of facility "${facilityId}"`
+        );
+      }
+      throw e;
+    }
+  }
+
+  public async createSpaceIndex(
+    facilityId: string,
+    itemType: FacilityItemType,
+    itemId: string
+  ): Promise<void> {
+    const itemIds = await this.getItemIds(facilityId, itemType);
+    const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
+
+    if (itemIds.length > 0) {
+      const spaceSet = new Set<string>(itemIds);
+      spaceSet.add(itemId);
+      await facilitySublevel.put(itemType, Array.from(spaceSet));
+    } else {
+      await facilitySublevel.put(itemType, [itemId]);
+    }
+  }
+
+  public async createSpaceItem(
+    facilityId: string,
+    itemType: FacilityItemType,
+    itemId: string,
+    key: string,
+    value: Item | FacilitySpaceLevelValues
+  ): Promise<void> {
+    const sublevel = this.dbService.getFacilityItemDB(
+      facilityId,
+      itemType,
+      itemId
+    );
+
+    await sublevel.put(key, value);
+  }
 }
+
+export default new FacilityRepository();

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -138,11 +138,9 @@ export class FacilityRepository {
     key: string,
     value: Item | FacilitySpaceValues
   ): Promise<void> {
-   await this.dbService.getFacilityItemDB(
-      facilityId,
-      itemType,
-      itemId
-    ).put(key, value);
+    await this.dbService
+      .getFacilityItemDB(facilityId, itemType, itemId)
+      .put(key, value);
   }
 
   public async getItemKey(
@@ -164,7 +162,6 @@ export class FacilityRepository {
       throw e;
     }
   }
-
 }
 
 export default new FacilityRepository();

--- a/src/repositories/MainRepository.ts
+++ b/src/repositories/MainRepository.ts
@@ -1,0 +1,29 @@
+import DBService from '../services/DBService';
+import { Level } from 'level';
+
+export class MainRepository {
+  private dbService: DBService;
+  private db: Level<string, string | string[]>;
+
+  constructor() {
+    this.dbService = DBService.getInstance();
+    this.db = DBService.getInstance().getDB();
+  }
+
+  public async getId(): Promise<number> {
+    try {
+      return (Number(await this.db.get('user_db_increment'))) + 1;
+    } catch (e) {
+      if (e.status === 404) {
+        return 1;
+      }
+      throw e;
+    }
+  }
+
+  public async setUserDBIncrement(id: string) {
+    await this.db.put('user_db_increment', id);
+  }
+}
+
+export default new MainRepository();

--- a/src/repositories/MainRepository.ts
+++ b/src/repositories/MainRepository.ts
@@ -12,7 +12,7 @@ export class MainRepository {
 
   public async getId(): Promise<number> {
     try {
-      return (Number(await this.db.get('user_db_increment'))) + 1;
+      return Number(await this.db.get('user_db_increment')) + 1;
     } catch (e) {
       if (e.status === 404) {
         return 1;

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -18,10 +18,7 @@ export class SpaceAvailabilityRepository {
 
   constructor(facilityId: string, spaceId: string) {
     this.dbService = DBService.getInstance();
-    this.db = this.dbService.getSpaceAvailabilityDB(
-      facilityId,
-      spaceId
-    );
+    this.db = this.dbService.getSpaceAvailabilityDB(facilityId, spaceId);
   }
 
   // --- availability getters / setters
@@ -39,10 +36,12 @@ export class SpaceAvailabilityRepository {
 
     return {
       numSpaces: 0
-    }
+    };
   }
 
-  public async setAvailabilityDefault(availability: Availability): Promise<void> {
+  public async setAvailabilityDefault(
+    availability: Availability
+  ): Promise<void> {
     await this.db.put('default', availability);
   }
 

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -9,7 +9,7 @@ import { Availability } from '../proto/lpms';
 
 export class SpaceAvailabilityRepository {
   private dbService: DBService;
-  private availableDB: AbstractSublevel<
+  private db: AbstractSublevel<
     AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>,
     LevelDefaultTyping,
     AvailabilityItemKey,
@@ -18,45 +18,38 @@ export class SpaceAvailabilityRepository {
 
   constructor(facilityId: string, spaceId: string) {
     this.dbService = DBService.getInstance();
-    this.availableDB = this.dbService.getSpaceAvailabilityDB(
+    this.db = this.dbService.getSpaceAvailabilityDB(
       facilityId,
       spaceId
     );
   }
 
-  public async getSpaceAvailabilityNumSpaces(
+  // --- availability getters / setters
+
+  public async getSpaceAvailability(
     key: AvailabilityItemKey
-  ): Promise<number> {
+  ): Promise<Availability> {
     try {
-      const availability: Availability = await this.availableDB.get(key);
-      return availability.numSpaces;
+      return await this.db.get(key);
     } catch (e) {
       if (e.status !== 404) {
         throw e;
       }
     }
 
-    return 0;
+    return {
+      numSpaces: 0
+    }
   }
 
-  public async createDefaultAvailability(numSpaces: number): Promise<void> {
-    const availability: Availability = {
-      numSpaces
-    };
-
-    await this.availableDB.put('default', availability);
+  public async setAvailabilityDefault(availability: Availability): Promise<void> {
+    await this.db.put('default', availability);
   }
 
-  public async createAvailabilityByDate(
+  public async setAvailabilityByDate(
     key: AvailabilityDate,
-    numSpaces = 1
+    availability: Availability
   ): Promise<void> {
-    const count = await this.getSpaceAvailabilityNumSpaces(key);
-
-    const availability: Availability = {
-      numSpaces: count + numSpaces
-    };
-
-    await this.availableDB.put(key, availability);
+    await this.db.put(key, availability);
   }
 }

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -1,6 +1,6 @@
 import DBService, {
-  AvailabilityDate,
-  AvailabilityItemKey,
+  FormattedDate,
+  DefaultOrDateItemKey,
   FacilityItemValues,
   LevelDefaultTyping
 } from '../services/DBService';
@@ -12,7 +12,7 @@ export class SpaceAvailabilityRepository {
   private db: AbstractSublevel<
     AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>,
     LevelDefaultTyping,
-    AvailabilityItemKey,
+    DefaultOrDateItemKey,
     Availability
   >;
 
@@ -27,7 +27,7 @@ export class SpaceAvailabilityRepository {
   // --- availability getters / setters
 
   public async getSpaceAvailability(
-    key: AvailabilityItemKey
+    key: DefaultOrDateItemKey
   ): Promise<Availability> {
     try {
       return await this.db.get(key);
@@ -47,7 +47,7 @@ export class SpaceAvailabilityRepository {
   }
 
   public async setAvailabilityByDate(
-    key: AvailabilityDate,
+    key: FormattedDate,
     availability: Availability
   ): Promise<void> {
     await this.db.put(key, availability);

--- a/src/repositories/TokenRepository.ts
+++ b/src/repositories/TokenRepository.ts
@@ -20,14 +20,14 @@ export class TokenRepository {
     }
   }
 
-  public async putUserTokens(
+  public async setUserTokens(
     userId: string,
     verifiedTokens: string[]
   ): Promise<void> {
     await this.db.put(userId, verifiedTokens);
   }
 
-  public async deleteUserTokens(userId: string): Promise<void> {
+  public async delUserTokens(userId: string): Promise<void> {
     await this.db.del(String(userId));
   }
 }

--- a/src/repositories/TokenRepository.ts
+++ b/src/repositories/TokenRepository.ts
@@ -1,0 +1,35 @@
+import DBService from '../services/DBService';
+
+export class TokenRepository {
+  private dbService: DBService;
+  private db;
+
+  constructor() {
+    this.dbService = DBService.getInstance();
+    this.db = DBService.getInstance().getTokenDB();
+  }
+
+  public async getUserTokens(userId: number): Promise<string[]> {
+    try {
+      return await this.db.get(String(userId));
+    } catch (e) {
+      if (e.status === 404) {
+        return [];
+      }
+      throw e;
+    }
+  }
+
+  public async putUserTokens(
+    userId: string,
+    verifiedTokens: string[]
+  ): Promise<void> {
+    await this.db.put(userId, verifiedTokens);
+  }
+
+  public async deleteUserTokens(userId: string): Promise<void> {
+    await this.db.del(String(userId));
+  }
+}
+
+export default new TokenRepository();

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -7,7 +7,12 @@ export class UserRepository {
   private dbService: DBService;
   private db: Level<string, string | string[]>;
   private userDB: AbstractSublevel<DBLevel, LevelDefaultTyping, string, User>;
-  private loginDB: AbstractSublevel<DBLevel, LevelDefaultTyping, string, string>;
+  private loginDB: AbstractSublevel<
+    DBLevel,
+    LevelDefaultTyping,
+    string,
+    string
+  >;
 
   constructor() {
     this.dbService = DBService.getInstance();
@@ -15,7 +20,6 @@ export class UserRepository {
     this.userDB = DBService.getInstance().getUserDB();
     this.loginDB = this.dbService.getLoginDB();
   }
-
 
   public async getAllUsers(): Promise<User[]> {
     return await this.userDB.values().all();

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -1,0 +1,66 @@
+import { AppRole, User } from '../types';
+import DBService, { DBLevel, LevelDefaultTyping } from '../services/DBService';
+import { Level } from 'level';
+import { AbstractSublevel } from 'abstract-level';
+
+export class UserRepository {
+  private dbService: DBService;
+  private db: Level<string, string | string[]>;
+  private userDB: AbstractSublevel<DBLevel, LevelDefaultTyping, string, User>;
+  private loginDB: AbstractSublevel<DBLevel, LevelDefaultTyping, string, string>;
+
+  constructor() {
+    this.dbService = DBService.getInstance();
+    this.db = DBService.getInstance().getDB();
+    this.userDB = DBService.getInstance().getUserDB();
+    this.loginDB = this.dbService.getLoginDB();
+  }
+
+
+  public async getAllUsers(): Promise<User[]> {
+    return await this.userDB.values().all();
+  }
+
+  public async getUserIdByLogin(login: string): Promise<number | null> {
+    try {
+      const userId = await this.loginDB.get(login);
+      return Number(userId);
+    } catch (e) {
+      if (e.status === 404) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  public async getUserById(id: number): Promise<User> {
+    return await this.userDB.get(String(id));
+  }
+
+  public async createUser(
+    id: number,
+    login: string,
+    password: string,
+    roles: AppRole[]
+  ): Promise<void> {
+    await this.userDB.put(String(id), {
+      id,
+      login,
+      password,
+      roles
+    });
+
+    await this.loginDB.put(login, String(id));
+  }
+
+  public async deleteUser(userId: string, login: string): Promise<void> {
+    await this.db.del(String(userId));
+    await this.loginDB.del(login);
+  }
+
+  public async updateUser(userId: string, user: User): Promise<void> {
+    await this.userDB.put(String(userId), user);
+  }
+}
+
+export default new UserRepository();

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -1,7 +1,11 @@
 import { AbstractSublevel } from 'abstract-level';
 import { Level } from 'level';
 import { Token, User } from '../types';
-import { Facility, Item, Space } from '../proto/facility';
+import {
+  Facility as FacilityMetadata,
+  Item as ItemMetadata,
+  Space as SpaceMetadata
+} from '../proto/facility';
 import {
   Availability,
   DayOfWeekLOSRule,
@@ -24,10 +28,10 @@ export type FacilityModifiers =
   | DayOfWeekRateModifer
   | OccupancyRateModifier
   | LOSRateModifier;
-export type FacilityLevelValues = Facility | string[];
-export type FacilitySpaceLevelValues = Item | Space;
+export type FacilityValues = FacilityMetadata | string[];
+export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
 export type FacilityItemType = 'spaces' | 'otherItems';
-export type FacilityItemValues = Item | FacilitySpaceLevelValues;
+export type FacilityItemValues = ItemMetadata | FacilitySpaceValues;
 export type AvailabilityDate = `${number}-${number}-${number}`;
 export type AvailabilityItemKey = 'default' | AvailabilityDate;
 
@@ -95,9 +99,9 @@ export default class DBService {
     return this.db;
   }
 
-  public getFacilitySublevelDB(facilityId: string) {
+  public getFacilityDB(facilityId: string) {
     const prefix = 'f_';
-    return this.db.sublevel<string, FacilityLevelValues>(prefix + facilityId, {
+    return this.db.sublevel<string, FacilityValues>(prefix + facilityId, {
       valueEncoding: 'json'
     });
   }
@@ -108,10 +112,10 @@ export default class DBService {
     itemId: string
   ) {
     const key = `${itemType}_${itemId}`;
-    return this.getFacilitySublevelDB(facilityId).sublevel<
-      string,
-      FacilityItemValues
-    >(key, { valueEncoding: 'json' });
+    return this.getFacilityDB(facilityId).sublevel<string, FacilityItemValues>(
+      key,
+      { valueEncoding: 'json' }
+    );
   }
 
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -12,8 +12,11 @@ import {
   DayOfWeekRateModifer,
   LOSRateModifier,
   NoticeRequiredRule,
-  OccupancyRateModifier
+  OccupancyRateModifier,
+  Rates
 } from '../proto/lpms';
+import { Stub } from '../proto/stub';
+import { Person } from '../proto/person';
 
 export type LevelDefaultTyping = string | Buffer | Uint8Array;
 export type DBLevel = Level<string, string | string[]>;
@@ -23,17 +26,26 @@ export type StringAbstractDB = AbstractSublevel<
   string,
   string
 >;
-export type FacilityRules = NoticeRequiredRule | DayOfWeekLOSRule;
-export type FacilityModifiers =
+export type Rules = NoticeRequiredRule | DayOfWeekLOSRule;
+export type RulesItemKey = 'notice_required' | 'length_of_stay';
+export type ModifiersValues =
   | DayOfWeekRateModifer
   | OccupancyRateModifier
   | LOSRateModifier;
+export type ModifiersKey =
+  | 'day_of_week'
+  | 'occupancy'
+  | 'length_of_stay'
 export type FacilityValues = FacilityMetadata | string[];
 export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
 export type FacilityItemType = 'spaces' | 'otherItems';
 export type FacilityItemValues = ItemMetadata | FacilitySpaceValues;
-export type AvailabilityDate = `${number}-${number}-${number}`;
-export type AvailabilityItemKey = 'default' | AvailabilityDate;
+export type FormattedDate = `${number}-${number}-${number}`;
+export type DefaultOrDateItemKey = 'default' | FormattedDate;
+export type FacilityStubKey = string | FormattedDate;
+export type FacilityStubValues = string[] | Stub;
+export type SpaceStubKey = FormattedDate | `${FormattedDate}-num_booked`;
+export type SpaceStubValues = string[] | number;
 
 export default class DBService {
   protected db: DBLevel;
@@ -118,10 +130,66 @@ export default class DBService {
     );
   }
 
+  public getFacilityRulesDB(facilityId: string) {
+    return this.getFacilityDB(facilityId).sublevel<RulesItemKey, Rules>(
+      'rules',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getFacilityModifiersDB(facilityId: string) {
+    return this.getFacilityDB(facilityId).sublevel<ModifiersKey, ModifiersValues>(
+      'modifiers',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getFacilityStubsDB(facilityId: string) {
+    return this.getFacilityDB(facilityId).sublevel<FacilityStubKey, FacilityStubValues>(
+      'stubs',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getFacilityPiiDB(facilityId: string) {
+    return this.getFacilityDB(facilityId).sublevel<string, Person>(
+      'pii',
+      { valueEncoding: 'json' }
+    );
+  }
+
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<
-      AvailabilityItemKey,
-      Availability
-    >('availability', { valueEncoding: 'json' });
+    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<DefaultOrDateItemKey, Availability>(
+      'availability',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getSpaceRatesDB(facilityId: string, spaceId: string) {
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<DefaultOrDateItemKey, Rates>(
+      'rates',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getSpaceRulesDB(facilityId: string, spaceId: string) {
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<RulesItemKey, Rules>(
+      'rules',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getSpaceModifiersDB(facilityId: string, spaceId: string) {
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<ModifiersKey, ModifiersValues>(
+      'modifiers',
+      { valueEncoding: 'json' }
+    );
+  }
+
+  public getSpaceStubsDB(facilityId: string, spaceId: string) {
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<SpaceStubKey, SpaceStubValues>(
+      'stubs',
+      { valueEncoding: 'json' }
+    );
   }
 }

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -32,10 +32,7 @@ export type ModifiersValues =
   | DayOfWeekRateModifer
   | OccupancyRateModifier
   | LOSRateModifier;
-export type ModifiersKey =
-  | 'day_of_week'
-  | 'occupancy'
-  | 'length_of_stay'
+export type ModifiersKey = 'day_of_week' | 'occupancy' | 'length_of_stay';
 export type FacilityValues = FacilityMetadata | string[];
 export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
 export type FacilityItemType = 'spaces' | 'otherItems';
@@ -138,58 +135,57 @@ export default class DBService {
   }
 
   public getFacilityModifiersDB(facilityId: string) {
-    return this.getFacilityDB(facilityId).sublevel<ModifiersKey, ModifiersValues>(
-      'modifiers',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityDB(facilityId).sublevel<
+      ModifiersKey,
+      ModifiersValues
+    >('modifiers', { valueEncoding: 'json' });
   }
 
   public getFacilityStubsDB(facilityId: string) {
-    return this.getFacilityDB(facilityId).sublevel<FacilityStubKey, FacilityStubValues>(
-      'stubs',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityDB(facilityId).sublevel<
+      FacilityStubKey,
+      FacilityStubValues
+    >('stubs', { valueEncoding: 'json' });
   }
 
   public getFacilityPiiDB(facilityId: string) {
-    return this.getFacilityDB(facilityId).sublevel<string, Person>(
-      'pii',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityDB(facilityId).sublevel<string, Person>('pii', {
+      valueEncoding: 'json'
+    });
   }
 
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<DefaultOrDateItemKey, Availability>(
-      'availability',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<
+      DefaultOrDateItemKey,
+      Availability
+    >('availability', { valueEncoding: 'json' });
   }
 
   public getSpaceRatesDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<DefaultOrDateItemKey, Rates>(
-      'rates',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
+      DefaultOrDateItemKey,
+      Rates
+    >('rates', { valueEncoding: 'json' });
   }
 
   public getSpaceRulesDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<RulesItemKey, Rules>(
-      'rules',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
+      RulesItemKey,
+      Rules
+    >('rules', { valueEncoding: 'json' });
   }
 
   public getSpaceModifiersDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<ModifiersKey, ModifiersValues>(
-      'modifiers',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
+      ModifiersKey,
+      ModifiersValues
+    >('modifiers', { valueEncoding: 'json' });
   }
 
   public getSpaceStubsDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<SpaceStubKey, SpaceStubValues>(
-      'stubs',
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
+      SpaceStubKey,
+      SpaceStubValues
+    >('stubs', { valueEncoding: 'json' });
   }
 }

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -1,6 +1,12 @@
 import { Item } from '../proto/facility';
-import { FacilityItemType, FacilityLevelValues, FacilitySpaceLevelValues } from './DBService';
-import facilityRepository, { FacilityRepository } from '../repositories/FacilityRepository';
+import {
+  FacilityItemType,
+  FacilityValues,
+  FacilitySpaceValues
+} from './DBService';
+import facilityRepository, {
+  FacilityRepository
+} from '../repositories/FacilityRepository';
 
 export class FacilityService {
   private repository: FacilityRepository;
@@ -11,13 +17,14 @@ export class FacilityService {
 
   public async setFacilityDbKeys(
     facilityId: string,
-    entries: [string, FacilityLevelValues][]
+    entries: [string, FacilityValues][]
   ): Promise<void> {
-    await this.repository.createFacilityIndex(facilityId);
+    await this.repository.addFacilityToIndex(facilityId);
 
     await Promise.all(
       entries.map(([key, value]) =>
-        this.repository.createFacilityItem(facilityId, key, value))
+        this.repository.setFacilityKey(facilityId, key, value)
+      )
     );
   }
 
@@ -25,12 +32,21 @@ export class FacilityService {
     facilityId: string,
     itemType: FacilityItemType,
     itemId: string,
-    entries: [string, Item | FacilitySpaceLevelValues][]
+    entries: [string, Item | FacilitySpaceValues][]
   ): Promise<void> {
-    await this.repository.createSpaceIndex(facilityId, itemType, itemId);
+    await this.repository.addItemToIndex(facilityId, itemType, itemId);
 
-    await Promise.all(entries.map(([key, value]) =>
-      this.repository.createSpaceItem(facilityId, itemType, itemId, key, value)));
+    await Promise.all(
+      entries.map(([key, value]) =>
+        this.repository.setItemKey(
+          facilityId,
+          itemType,
+          itemId,
+          key,
+          value
+        )
+      )
+    );
   }
 }
 

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -38,13 +38,7 @@ export class FacilityService {
 
     await Promise.all(
       entries.map(([key, value]) =>
-        this.repository.setItemKey(
-          facilityId,
-          itemType,
-          itemId,
-          key,
-          value
-        )
+        this.repository.setItemKey(facilityId, itemType, itemId, key, value)
       )
     );
   }

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -1,101 +1,23 @@
-import { Level } from 'level';
 import { Item } from '../proto/facility';
-import DBService, {
-  FacilityItemType,
-  FacilityLevelValues,
-  FacilitySpaceLevelValues
-} from './DBService';
+import { FacilityItemType, FacilityLevelValues, FacilitySpaceLevelValues } from './DBService';
+import facilityRepository, { FacilityRepository } from '../repositories/FacilityRepository';
 
 export class FacilityService {
-  private dbService: DBService;
-  private db: Level<string, string | string[]>;
+  private repository: FacilityRepository;
 
   constructor() {
-    this.dbService = DBService.getInstance();
-    this.db = this.dbService.getDB();
-  }
-
-  public async getFacilityIds(): Promise<string[]> {
-    try {
-      return await this.db.get<string, string[]>('facilities', {
-        valueEncoding: 'json'
-      });
-    } catch (e) {
-      if (e.status !== 404) {
-        throw e;
-      }
-    }
-    return [];
-  }
-
-  public async getItemIds(
-    facilityId: string,
-    itemType: FacilityItemType
-  ): Promise<string[]> {
-    try {
-      const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
-      return await facilitySublevel.get<string, string[]>(itemType, {
-        valueEncoding: 'json'
-      });
-    } catch (e) {
-      if (e.status !== 404) {
-        throw e;
-      }
-    }
-    return [];
-  }
-
-  public async getFacilityDbKey(
-    facilityId: string,
-    key: string
-  ): Promise<FacilityLevelValues> {
-    try {
-      return await this.dbService.getFacilitySublevelDB(facilityId).get(key);
-    } catch (e) {
-      if (e.status === 404) {
-        throw new Error(`Unable to get "${key}" of facility "${facilityId}"`);
-      }
-      throw e;
-    }
-  }
-
-  public async getSpaceDbKey(
-    facilityId: string,
-    spaceId: string,
-    key: string
-  ): Promise<FacilitySpaceLevelValues> {
-    try {
-      return await this.dbService
-        .getFacilityItemDB(facilityId, 'spaces', spaceId)
-        .get(key);
-    } catch (e) {
-      if (e.status === 404) {
-        throw new Error(
-          `Unable to get "${key}" of space "${spaceId}" of facility "${facilityId}"`
-        );
-      }
-      throw e;
-    }
+    this.repository = facilityRepository;
   }
 
   public async setFacilityDbKeys(
     facilityId: string,
     entries: [string, FacilityLevelValues][]
   ): Promise<void> {
-    const ids = await this.getFacilityIds();
-
-    if (ids.length > 0) {
-      const idsSet = new Set<string>(ids);
-      idsSet.add(facilityId);
-      await this.db.put('facilities', Array.from(idsSet));
-    } else {
-      await this.db.put('facilities', [facilityId]);
-    }
-
-    const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
+    await this.repository.createFacilityIndex(facilityId);
 
     await Promise.all(
-      entries.map(([key, value]) => facilitySublevel.put(key, value))
+      entries.map(([key, value]) =>
+        this.repository.createFacilityItem(facilityId, key, value))
     );
   }
 
@@ -105,24 +27,10 @@ export class FacilityService {
     itemId: string,
     entries: [string, Item | FacilitySpaceLevelValues][]
   ): Promise<void> {
-    const itemIds = await this.getItemIds(facilityId, itemType);
-    const facilitySublevel = this.dbService.getFacilitySublevelDB(facilityId);
+    await this.repository.createSpaceIndex(facilityId, itemType, itemId);
 
-    if (itemIds.length > 0) {
-      const spaceSet = new Set<string>(itemIds);
-      spaceSet.add(itemId);
-      await facilitySublevel.put(itemType, Array.from(spaceSet));
-    } else {
-      await facilitySublevel.put(itemType, [itemId]);
-    }
-
-    const sublevel = this.dbService.getFacilityItemDB(
-      facilityId,
-      itemType,
-      itemId
-    );
-
-    await Promise.all(entries.map(([key, value]) => sublevel.put(key, value)));
+    await Promise.all(entries.map(([key, value]) =>
+      this.repository.createSpaceItem(facilityId, itemType, itemId, key, value)));
   }
 }
 

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { Ask } from 'src/proto/ask';
 import { Space } from '../proto/facility';
-import { AvailabilityDate } from './DBService';
+import { FormattedDate } from './DBService';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
 import facilityRepository from '../repositories/FacilityRepository';
 
@@ -125,7 +125,7 @@ export default class SpaceSearchService {
       try {
         const dailyBooks =
           await availabilityRepository.getSpaceAvailability(
-            from.toFormat('yyyy-MM-dd') as AvailabilityDate
+            from.toFormat('yyyy-MM-dd') as FormattedDate
           );
 
         throw('To be implemented')

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -1,36 +1,23 @@
 import { DateTime } from 'luxon';
 import { Ask } from 'src/proto/ask';
 import { Space } from '../proto/facility';
-import DBService, { AvailabilityDate } from './DBService';
+import { AvailabilityDate } from './DBService';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
+import facilityRepository from '../repositories/FacilityRepository';
 
 export default class SpaceSearchService {
-  static dbService = DBService.getInstance();
-
   public static async check(ask: Ask, facilityId: string): Promise<Space[]> {
-    const facilityDB =
-      SpaceSearchService.dbService.getFacilitySublevelDB(facilityId);
-    let spacesIds;
-
-    try {
-      spacesIds = await facilityDB.get('spaces');
-    } catch (e) {
-      if (e.status !== 404) {
-        throw e;
-      }
-      return []; //todo throw error?
-    }
+    const spacesIds = await facilityRepository.getFacilityDbKey(facilityId, 'spaces');
 
     if (Array.isArray(spacesIds)) {
       const set = new Set();
 
       for (const v of spacesIds) {
-        const spaceDB = SpaceSearchService.dbService.getFacilityItemDB(
+        const space = await facilityRepository.getSpaceDbKey(
           facilityId,
-          'spaces',
-          v
+          v,
+          'metadata'
         );
-        const space = await spaceDB.get('metadata');
         set.add({ space, id: v });
       }
 

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -7,14 +7,15 @@ import facilityRepository from '../repositories/FacilityRepository';
 
 export default class SpaceSearchService {
   public static async check(ask: Ask, facilityId: string): Promise<Space[]> {
-    const spacesIds = await facilityRepository.getFacilityDbKey(facilityId, 'spaces');
+    const spacesIds = await facilityRepository.getFacilityKey(facilityId, 'spaces');
 
     if (Array.isArray(spacesIds)) {
       const set = new Set();
 
       for (const v of spacesIds) {
-        const space = await facilityRepository.getSpaceDbKey(
+        const space = await facilityRepository.getItemKey(
           facilityId,
+          'spaces',
           v,
           'metadata'
         );

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -7,7 +7,10 @@ import facilityRepository from '../repositories/FacilityRepository';
 
 export default class SpaceSearchService {
   public static async check(ask: Ask, facilityId: string): Promise<Space[]> {
-    const spacesIds = await facilityRepository.getFacilityKey(facilityId, 'spaces');
+    const spacesIds = await facilityRepository.getFacilityKey(
+      facilityId,
+      'spaces'
+    );
 
     if (Array.isArray(spacesIds)) {
       const set = new Set();

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -116,7 +116,7 @@ export default class SpaceSearchService {
     );
 
     const defaultAvailable =
-      await availabilityRepository.getSpaceAvailabilityNumSpaces('default');
+      await availabilityRepository.getSpaceAvailability('default');
 
     let from = DateTime.fromObject(checkIn);
     const to = DateTime.fromObject(checkOut);
@@ -124,11 +124,20 @@ export default class SpaceSearchService {
     while (from <= to) {
       try {
         const dailyBooks =
-          await availabilityRepository.getSpaceAvailabilityNumSpaces(
+          await availabilityRepository.getSpaceAvailability(
             from.toFormat('yyyy-MM-dd') as AvailabilityDate
           );
 
-        if (defaultAvailable - dailyBooks < spacesRequired) {
+        throw('To be implemented')
+        // In order to determine if there is space availability, a routine would have to:
+        // Get total number of spaces, with *per-day override* having higher priority than
+        // default. This will be the 'capacity' - ie. HOW MANY OF THOSE SPACE TYPES ARE
+        // PRESENT FOR THE POINT OF CONSIDERING IF THEY CAN BE STAYED IN.
+        // Then get the number of that space type that are booked. This means get the 
+        // facilityId.spaceId.stubs sublevel and get the YYYY-MM-DD-num_booked key
+        // this would be the number of daily booked.
+        // if the total number of spaces - booked spaces < spacesRequired, true false
+        if (defaultAvailable.numSpaces - dailyBooks.numSpaces < spacesRequired) {
           return false;
         }
       } catch (e) {

--- a/src/services/SpaceSearchService.ts
+++ b/src/services/SpaceSearchService.ts
@@ -115,29 +115,32 @@ export default class SpaceSearchService {
       spaceId
     );
 
-    const defaultAvailable =
-      await availabilityRepository.getSpaceAvailability('default');
+    const defaultAvailable = await availabilityRepository.getSpaceAvailability(
+      'default'
+    );
 
     let from = DateTime.fromObject(checkIn);
     const to = DateTime.fromObject(checkOut);
 
     while (from <= to) {
       try {
-        const dailyBooks =
-          await availabilityRepository.getSpaceAvailability(
-            from.toFormat('yyyy-MM-dd') as FormattedDate
-          );
+        const dailyBooks = await availabilityRepository.getSpaceAvailability(
+          from.toFormat('yyyy-MM-dd') as FormattedDate
+        );
 
-        throw('To be implemented')
+        throw 'To be implemented';
         // In order to determine if there is space availability, a routine would have to:
         // Get total number of spaces, with *per-day override* having higher priority than
         // default. This will be the 'capacity' - ie. HOW MANY OF THOSE SPACE TYPES ARE
         // PRESENT FOR THE POINT OF CONSIDERING IF THEY CAN BE STAYED IN.
-        // Then get the number of that space type that are booked. This means get the 
+        // Then get the number of that space type that are booked. This means get the
         // facilityId.spaceId.stubs sublevel and get the YYYY-MM-DD-num_booked key
         // this would be the number of daily booked.
         // if the total number of spaces - booked spaces < spacesRequired, true false
-        if (defaultAvailable.numSpaces - dailyBooks.numSpaces < spacesRequired) {
+        if (
+          defaultAvailable.numSpaces - dailyBooks.numSpaces <
+          spacesRequired
+        ) {
           return false;
         }
       } catch (e) {

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -1,7 +1,14 @@
 import jwt from 'jsonwebtoken';
-import { accessTokenKey, accessTokenMaxAge, refreshTokenKey, refreshTokenMaxAge } from '../config';
+import {
+  accessTokenKey,
+  accessTokenMaxAge,
+  refreshTokenKey,
+  refreshTokenMaxAge
+} from '../config';
 import { Tokens } from '../types';
-import tokenRepository, { TokenRepository } from '../repositories/TokenRepository';
+import tokenRepository, {
+  TokenRepository
+} from '../repositories/TokenRepository';
 
 export class TokenService {
   private repository: TokenRepository;

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -37,7 +37,7 @@ export class TokenService {
 
     verifiedTokens.push(refreshToken);
 
-    return await this.repository.putUserTokens(String(userId), verifiedTokens);
+    return await this.repository.setUserTokens(String(userId), verifiedTokens);
   }
 
   public getVerifiedUserTokens(tokens: Array<string>): string[] {
@@ -62,11 +62,11 @@ export class TokenService {
       return i !== token;
     });
 
-    return await this.repository.putUserTokens(String(userId), neededTokens);
+    return await this.repository.setUserTokens(String(userId), neededTokens);
   }
 
   public async revokeAllUserTokens(userId: number) {
-    return await this.repository.deleteUserTokens(String(userId));
+    return await this.repository.delUserTokens(String(userId));
   }
 
   public validateRefreshToken(refreshToken) {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -43,12 +43,7 @@ export class UserService {
     const id = await this.mainRepository.getId();
     const rounds = 2;
     const hashedPassword = await bcrypt.hash(String(password), rounds);
-    await this.repository.createUser(
-      id,
-      login,
-      hashedPassword,
-      roles
-    );
+    await this.repository.createUser(id, login, hashedPassword, roles);
 
     await this.mainRepository.setUserDBIncrement(String(id));
 
@@ -156,7 +151,9 @@ export class UserService {
   }
 
   private async deleteDefaultManagerAccount(): Promise<void> {
-    const managerId = await this.repository.getUserIdByLogin(defaultManagerLogin);
+    const managerId = await this.repository.getUserIdByLogin(
+      defaultManagerLogin
+    );
 
     if (managerId) {
       await this.deleteUser(managerId);

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,29 +1,26 @@
 import { AppRole, User, UserDTO } from '../types';
-import DBService from './DBService';
 import bcrypt from 'bcrypt';
 import tokenService, { TokenService } from './TokenService';
 import ApiError from '../exceptions/ApiError';
 import { defaultManagerLogin } from '../config';
 import { MetricsService } from './MetricsService';
+import userRepository, { UserRepository } from '../repositories/UserRepository';
+import mainRepository, { MainRepository } from '../repositories/MainRepository';
 
 export class UserService {
-  private db;
-  private loginDB;
-  private dbService: DBService;
-  private mainDB;
   private tokenService: TokenService;
+  private repository: UserRepository;
+  private mainRepository: MainRepository;
 
   constructor() {
-    this.dbService = DBService.getInstance();
-    this.db = this.dbService.getUserDB();
-    this.mainDB = this.dbService.getDB();
-    this.loginDB = this.dbService.getLoginDB();
     this.tokenService = tokenService;
+    this.repository = userRepository;
+    this.mainRepository = mainRepository;
   }
 
   public async getAllUsers() {
     const users = new Set<UserDTO>();
-    const dbUsers: User[] = await this.db.values().all();
+    const dbUsers: User[] = await this.repository.getAllUsers();
 
     dbUsers.map((i) => {
       const userDTO = this.getUserDTO(i);
@@ -38,62 +35,34 @@ export class UserService {
     password: string,
     roles: AppRole[]
   ): Promise<void> {
-    const userExists = await this.getUserIdByLogin(login);
+    const userExists = await this.repository.getUserIdByLogin(login);
     if (userExists) {
       throw ApiError.BadRequest('User already exists');
     }
 
-    const id = await this.getId();
+    const id = await this.mainRepository.getId();
     const rounds = 2;
     const hashedPassword = await bcrypt.hash(String(password), rounds);
-    await this.db.put(String(id), {
+    await this.repository.createUser(
       id,
       login,
-      password: hashedPassword,
+      hashedPassword,
       roles
-    });
+    );
 
-    await this.loginDB.put(login, String(id));
-    await this.mainDB.put('user_db_increment', id);
+    await this.mainRepository.setUserDBIncrement(String(id));
 
     if (login !== defaultManagerLogin && roles.includes(AppRole.MANAGER)) {
       await this.deleteDefaultManagerAccount();
     }
   }
 
-  private async getId(): Promise<number> {
-    try {
-      return (await this.mainDB.get('user_db_increment')) + 1;
-    } catch (e) {
-      if (e.status === 404) {
-        return 1;
-      }
-      throw e;
-    }
-  }
-
-  public async getUserIdByLogin(login: string): Promise<number | null> {
-    try {
-      const userId = await this.loginDB.get(login);
-      return Number(userId);
-    } catch (e) {
-      if (e.status === 404) {
-        return null;
-      }
-      throw e;
-    }
-  }
-
-  public async getUserById(id: number): Promise<User> {
-    return await this.db.get(String(id));
-  }
-
   public async getUserByLogin(login: string): Promise<User | null> {
-    const id = await this.getUserIdByLogin(login);
+    const id = await this.repository.getUserIdByLogin(login);
     if (!id) {
       return null;
     }
-    return await this.getUserById(id);
+    return await this.repository.getUserById(id);
   }
 
   public getUserDTO(user: User): UserDTO {
@@ -106,11 +75,10 @@ export class UserService {
 
   public async deleteUser(id: number): Promise<void> {
     try {
-      const user = await this.getUserById(id);
+      const user = await this.repository.getUserById(id);
       const login = user.login;
 
-      await this.db.del(String(id));
-      await this.loginDB.del(login);
+      await this.repository.deleteUser(String(id), login);
       await this.tokenService.revokeAllUserTokens(id);
     } catch (e) {
       if (e.status !== 404) {
@@ -175,7 +143,7 @@ export class UserService {
       throw ApiError.UnauthorizedError();
     }
 
-    const user = await this.getUserById(data.id);
+    const user = await this.repository.getUserById(data.id);
     const userDTO = this.getUserDTO(user);
     const tokens = this.tokenService.generateTokens(userDTO);
     await this.tokenService.revokeToken(refreshToken);
@@ -188,7 +156,7 @@ export class UserService {
   }
 
   private async deleteDefaultManagerAccount(): Promise<void> {
-    const managerId = await this.getUserIdByLogin(defaultManagerLogin);
+    const managerId = await this.repository.getUserIdByLogin(defaultManagerLogin);
 
     if (managerId) {
       await this.deleteUser(managerId);
@@ -200,11 +168,11 @@ export class UserService {
     password: string
   ): Promise<void> {
     try {
-      const user = await this.getUserById(userId);
+      const user = await this.repository.getUserById(userId);
       const rounds = 2;
       user.password = await bcrypt.hash(String(password), rounds);
 
-      await this.db.put(String(userId), user);
+      await this.repository.updateUser(String(userId), user);
     } catch (e) {
       if (e.status === 404) {
         throw ApiError.BadRequest('User not found');
@@ -218,10 +186,10 @@ export class UserService {
     roles: AppRole[]
   ): Promise<void> {
     try {
-      const user = await this.getUserById(userId);
+      const user = await this.repository.getUserById(userId);
       user.roles = roles;
 
-      await this.db.put(String(userId), user);
+      await this.repository.updateUser(String(userId), user);
     } catch (e) {
       if (e.status === 404) {
         throw ApiError.BadRequest('User not found');

--- a/test/package.spec.ts
+++ b/test/package.spec.ts
@@ -3,6 +3,7 @@ import supertest from 'supertest';
 import ServerService from '../src/services/ServerService';
 import { AppRole } from '../src/types';
 import userService from '../src/services/UserService';
+import userRepository from '../src/repositories/UserRepository';
 
 describe('test', async () => {
   const appService = await new ServerService(3005);
@@ -26,7 +27,7 @@ describe('test', async () => {
   it('make manager', async () => {
     await userService.createUser(managerLogin, managerPass, [AppRole.MANAGER]);
 
-    const userId = await userService.getUserIdByLogin(managerLogin);
+    const userId = await userRepository.getUserIdByLogin(managerLogin);
     expect(userId).to.be.an('number');
   });
 
@@ -163,13 +164,13 @@ describe('test', async () => {
 
   it('delete users', async () => {
     //todo think about APIs for delete users
-    const id = await userService.getUserIdByLogin(managerLogin);
-    const anotherUser = await userService.getUserIdByLogin(anotherUserForTest);
+    const id = await userRepository.getUserIdByLogin(managerLogin);
+    const anotherUser = await userRepository.getUserIdByLogin(anotherUserForTest);
     await userService.deleteUser(Number(id));
     await userService.deleteUser(Number(staffUserId));
     await userService.deleteUser(Number(anotherUser));
 
-    const checkId = await userService.getUserIdByLogin(managerLogin);
+    const checkId = await userRepository.getUserIdByLogin(managerLogin);
     expect(checkId).to.be.null;
   });
 });

--- a/test/package.spec.ts
+++ b/test/package.spec.ts
@@ -165,7 +165,9 @@ describe('test', async () => {
   it('delete users', async () => {
     //todo think about APIs for delete users
     const id = await userRepository.getUserIdByLogin(managerLogin);
-    const anotherUser = await userRepository.getUserIdByLogin(anotherUserForTest);
+    const anotherUser = await userRepository.getUserIdByLogin(
+      anotherUserForTest
+    );
     await userService.deleteUser(Number(id));
     await userService.deleteUser(Number(staffUserId));
     await userService.deleteUser(Number(anotherUser));


### PR DESCRIPTION
This PR:

1. Adds missing `otherItems` rates to the storage schema.
2. Renames some keys associated with the `metadata` in spaces so that the terminology is aligned with `otherItems`.