### PR TITLE
Stubs Connector

### DIFF
--- a/src/repositories/SpaceStubRepository.ts
+++ b/src/repositories/SpaceStubRepository.ts
@@ -1,0 +1,89 @@
+import DBService, {
+  FormattedDate,
+  FacilityItemValues,
+  LevelDefaultTyping,
+  DBLevel,
+  FacilityValues,
+  SpaceStubKey,
+  SpaceStubValues
+} from '../services/DBService';
+import { AbstractSublevel } from 'abstract-level';
+
+export class SpaceStubRepository {
+  private dbService: DBService;
+  private db: AbstractSublevel<
+    AbstractSublevel<
+      AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
+      LevelDefaultTyping,
+      string,
+      FacilityItemValues
+    >,
+    LevelDefaultTyping,
+    SpaceStubKey,
+    SpaceStubValues
+  >;
+
+  constructor(facilityId: string, spaceId: string) {
+    this.dbService = DBService.getInstance();
+    this.db = this.dbService.getSpaceStubsDB(facilityId, spaceId);
+  }
+
+  // --- daily index management
+
+  public async getIndex(idx: FormattedDate): Promise<string[]> {
+    try {
+      return await this.db.get<FormattedDate, string[]>(idx, {
+        valueEncoding: 'json'
+      });
+    } catch (e) {
+      if (e.status !== 404) {
+        throw e;
+      }
+    }
+    return [];
+  }
+
+  public async addToIndex(idx: FormattedDate, stubId: string): Promise<void> {
+    const stubIds = await this.getIndex(idx);
+
+    if (stubIds.length > 0) {
+      const ids = new Set<string>(stubIds);
+      ids.add(stubId);
+      await this.db.put(idx, Array.from(ids));
+    } else {
+      await this.db.put(idx, [stubId]);
+    }
+  }
+
+  public async delFromIndex(idx: FormattedDate, itemId: string): Promise<void> {
+    const stubIds = await this.getIndex(idx);
+
+    if (stubIds.length > 0) {
+      const ids = new Set<string>(stubIds);
+      if (ids.delete(itemId)) {
+        await this.db.put(idx, Array.from(ids));
+      }
+    }
+  }
+
+  // --- num_booked getter / setter
+
+  public async getNumBookedByDate(key: SpaceStubKey): Promise<number> {
+    try {
+      return (await this.db.get(key)) as number;
+    } catch (e) {
+      if (e.status !== 404) {
+        throw e;
+      }
+    }
+
+    return 0;
+  }
+
+  public async setNumBookedByDate(
+    key: SpaceStubKey,
+    value: number
+  ): Promise<void> {
+    await this.db.put(key, value);
+  }
+}

--- a/src/repositories/StubRepository.ts
+++ b/src/repositories/StubRepository.ts
@@ -1,0 +1,80 @@
+import DBService, {
+  FormattedDate,
+  LevelDefaultTyping,
+  DBLevel,
+  FacilityStubValues,
+  FacilityValues,
+  FacilityStubKey
+} from '../services/DBService';
+import { AbstractSublevel } from 'abstract-level';
+import { StubStorage } from '../proto/lpms';
+
+export class StubRepository {
+  private dbService: DBService;
+  private db: AbstractSublevel<
+    AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
+    LevelDefaultTyping,
+    string,
+    FacilityStubValues
+  >;
+
+  constructor(facilityId: string) {
+    this.dbService = DBService.getInstance();
+    this.db = this.dbService.getFacilityStubsDB(facilityId);
+  }
+
+  // --- availability getters / setters
+
+  public async getStub(key: FacilityStubKey): Promise<FacilityStubValues> {
+    try {
+      return await this.db.get(key);
+    } catch (e) {
+      if (e.status === 404) {
+        throw new Error(`Unable to get "${key}" of stub level"`);
+      }
+      throw e;
+    }
+  }
+
+  public async setStub(key: FacilityStubKey, stub: StubStorage): Promise<void> {
+    await this.db.put(key, stub);
+  }
+
+  // --- daily index management
+
+  public async getIndex(idx: FormattedDate): Promise<string[]> {
+    try {
+      return await this.db.get<FormattedDate, string[]>(idx, {
+        valueEncoding: 'json'
+      });
+    } catch (e) {
+      if (e.status !== 404) {
+        throw e;
+      }
+    }
+    return [];
+  }
+
+  public async addToIndex(idx: FormattedDate, stubId: string): Promise<void> {
+    const stubIds = await this.getIndex(idx);
+
+    if (stubIds.length > 0) {
+      const ids = new Set<string>(stubIds);
+      ids.add(stubId);
+      await this.db.put(idx, Array.from(ids));
+    } else {
+      await this.db.put(idx, [stubId]);
+    }
+  }
+
+  public async delFromIndex(idx: FormattedDate, itemId: string): Promise<void> {
+    const stubIds = await this.getIndex(idx);
+
+    if (stubIds.length > 0) {
+      const ids = new Set<string>(stubIds);
+      if (ids.delete(itemId)) {
+        await this.db.put(idx, Array.from(ids));
+      }
+    }
+  }
+}

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -13,7 +13,8 @@ import {
   LOSRateModifier,
   NoticeRequiredRule,
   OccupancyRateModifier,
-  Rates
+  Rates,
+  StubStorage
 } from '../proto/lpms';
 import { Stub } from '../proto/stub';
 import { Person } from '../proto/person';
@@ -33,14 +34,15 @@ export type ModifiersValues =
   | OccupancyRateModifier
   | LOSRateModifier;
 export type ModifiersKey = 'day_of_week' | 'occupancy' | 'length_of_stay';
+export type FacilityKey = 'metadata';
+export type FacilityIndexKey = 'stubs' | 'spaces' | 'otherItems';
 export type FacilityValues = FacilityMetadata | string[];
 export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
-export type FacilityItemType = 'spaces' | 'otherItems';
 export type FacilityItemValues = ItemMetadata | FacilitySpaceValues;
 export type FormattedDate = `${number}-${number}-${number}`;
 export type DefaultOrDateItemKey = 'default' | FormattedDate;
 export type FacilityStubKey = string | FormattedDate;
-export type FacilityStubValues = string[] | Stub;
+export type FacilityStubValues = string[] | StubStorage;
 export type SpaceStubKey = FormattedDate | `${FormattedDate}-num_booked`;
 export type SpaceStubValues = string[] | number;
 
@@ -117,7 +119,7 @@ export default class DBService {
 
   public getFacilityItemDB(
     facilityId: string,
-    itemType: FacilityItemType,
+    itemType: FacilityIndexKey,
     itemId: string
   ) {
     const key = `${itemType}_${itemId}`;

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -2,7 +2,8 @@ import { Item } from '../proto/facility';
 import {
   FacilityIndexKey,
   FacilityValues,
-  FacilitySpaceValues
+  FacilitySpaceValues,
+  FacilityKey
 } from './DBService';
 import facilityRepository, {
   FacilityRepository
@@ -17,7 +18,7 @@ export class FacilityService {
 
   public async setFacilityDbKeys(
     facilityId: string,
-    entries: [string, FacilityValues][]
+    entries: [FacilityIndexKey | FacilityKey, FacilityValues][]
   ): Promise<void> {
     await this.repository.addFacilityToIndex(facilityId);
 

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -1,6 +1,6 @@
 import { Item } from '../proto/facility';
 import {
-  FacilityItemType,
+  FacilityIndexKey,
   FacilityValues,
   FacilitySpaceValues
 } from './DBService';
@@ -30,11 +30,11 @@ export class FacilityService {
 
   public async setItemDbKeys(
     facilityId: string,
-    itemType: FacilityItemType,
+    itemType: FacilityIndexKey,
     itemId: string,
     entries: [string, Item | FacilitySpaceValues][]
   ): Promise<void> {
-    await this.repository.addItemToIndex(facilityId, itemType, itemId);
+    await this.repository.addToIndex(facilityId, itemType, itemId);
 
     await Promise.all(
       entries.map(([key, value]) =>


### PR DESCRIPTION
This PR:

1. Adds a `stubs` index to the facility-specific sublevel.
2. Adds a `stubs` sublevel specific to each facility for storing the actual `stub.
3. Adds a `stubs` sublevel specific to each facility.space for storing a date index and num_booked counter.

Closes #16 