### PR TITLE
feat: modifier repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@protobuf-ts/plugin": "^2.6.0",
-    "@windingtree/stays-models": "^2.0.0",
+    "@windingtree/stays-models": "^2.0.1",
     "@windingtree/videre-sdk": "^0.5.0",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
@@ -88,7 +88,7 @@
     "@types/luxon": "^2.3.2",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
-    "@windingtree/videre-contracts": "^0.2.0-alpha.1",
+    "@windingtree/videre-contracts": "^1.0.2",
     "chai": "^4.3.6",
     "conventional-changelog-cli": "^2.2.2",
     "eslint": "^8.16.0",

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -9,9 +9,7 @@ import { DateTime } from 'luxon';
 import ApiError from '../exceptions/ApiError';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
 import { FacilityModifierRepository } from '../repositories/FacilityModifierRepository';
-import {
-  ItemModifierRepository
-} from '../repositories/ItemModifierRegistry';
+import { ItemModifierRepository } from '../repositories/ItemModifierRegistry';
 
 export class FacilityController {
   // Returns availability of the space
@@ -194,9 +192,7 @@ export class FacilityController {
       const { facilityId, modifierKey } = req.params;
 
       const repository = new FacilityModifierRepository(facilityId);
-      await repository.delModifier(
-        modifierKey as ModifiersKey
-      );
+      await repository.delModifier(modifierKey as ModifiersKey);
 
       res.json({ success: true });
     } catch (e) {
@@ -219,9 +215,7 @@ export class FacilityController {
         itemId
       );
 
-      await repository.delModifier(
-        modifierKey as ModifiersKey
-      );
+      await repository.delModifier(modifierKey as ModifiersKey);
 
       res.json({ success: true });
     } catch (e) {

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import type {
+  FacilityIndexKey,
   FormattedDate,
   ModifiersKey,
   ModifiersValues
@@ -9,8 +10,7 @@ import ApiError from '../exceptions/ApiError';
 import { SpaceAvailabilityRepository } from '../repositories/SpaceAvailabilityRepository';
 import { FacilityModifierRepository } from '../repositories/FacilityModifierRepository';
 import {
-  SpaceModifierRepository,
-  OtherItemsModifierRepository
+  ItemModifierRepository
 } from '../repositories/ItemModifierRegistry';
 
 export class FacilityController {
@@ -106,18 +106,12 @@ export class FacilityController {
   ) => {
     try {
       const { facilityId, itemKey, itemId, modifierKey } = req.params;
-      let repository: SpaceModifierRepository | OtherItemsModifierRepository;
 
-      switch (itemKey) {
-        case 'spaces':
-          repository = new SpaceModifierRepository(facilityId, itemId);
-          break;
-        case 'otherItems':
-          repository = new OtherItemsModifierRepository(facilityId, itemId);
-          break;
-        default:
-          throw ApiError.BadRequest('Invalid item key');
-      }
+      const repository = new ItemModifierRepository(
+        facilityId,
+        itemKey as FacilityIndexKey,
+        itemId
+      );
 
       let modifier: ModifiersValues;
 
@@ -172,18 +166,12 @@ export class FacilityController {
     try {
       const { facilityId, itemKey, itemId, modifierKey } = req.params;
       const modifier = req.body;
-      let repository: SpaceModifierRepository | OtherItemsModifierRepository;
 
-      switch (itemKey) {
-        case 'spaces':
-          repository = new SpaceModifierRepository(facilityId, itemId);
-          break;
-        case 'otherItems':
-          repository = new OtherItemsModifierRepository(facilityId, itemId);
-          break;
-        default:
-          throw ApiError.BadRequest('Invalid item key');
-      }
+      const repository = new ItemModifierRepository(
+        facilityId,
+        itemKey as FacilityIndexKey,
+        itemId
+      );
 
       await repository.setModifier(
         modifierKey as ModifiersKey,
@@ -224,18 +212,12 @@ export class FacilityController {
   ) => {
     try {
       const { facilityId, itemKey, itemId, modifierKey } = req.params;
-      let repository: SpaceModifierRepository | OtherItemsModifierRepository;
 
-      switch (itemKey) {
-        case 'spaces':
-          repository = new SpaceModifierRepository(facilityId, itemId);
-          break;
-        case 'otherItems':
-          repository = new OtherItemsModifierRepository(facilityId, itemId);
-          break;
-        default:
-          throw ApiError.BadRequest('Invalid item key');
-      }
+      const repository = new ItemModifierRepository(
+        facilityId,
+        itemKey as FacilityIndexKey,
+        itemId
+      );
 
       await repository.delModifier(
         modifierKey as ModifiersKey

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -195,6 +195,57 @@ export class FacilityController {
       next(e);
     }
   };
+
+  // Removes a modifier from the facility
+  removeModifierOfFacility = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { facilityId, modifierKey } = req.params;
+
+      const repository = new FacilityModifierRepository(facilityId);
+      await repository.delModifier(
+        modifierKey as ModifiersKey
+      );
+
+      res.json({ success: true });
+    } catch (e) {
+      next(e);
+    }
+  };
+
+  // Removes modifier of the item: `spaces` or `otherItems`
+  removeModifierOfItem = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { facilityId, itemKey, itemId, modifierKey } = req.params;
+      let repository: SpaceModifierRepository | OtherItemsModifierRepository;
+
+      switch (itemKey) {
+        case 'spaces':
+          repository = new SpaceModifierRepository(facilityId, itemId);
+          break;
+        case 'otherItems':
+          repository = new OtherItemsModifierRepository(facilityId, itemId);
+          break;
+        default:
+          throw ApiError.BadRequest('Invalid item key');
+      }
+
+      await repository.delModifier(
+        modifierKey as ModifiersKey
+      );
+
+      res.json({ success: true });
+    } catch (e) {
+      next(e);
+    }
+  };
 }
 
 export default new FacilityController();

--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -134,6 +134,23 @@ export class FacilityController {
       next(e);
     }
   };
+
+  createFacilityModifier = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { facilityId, modifierKey } = req.params;
+      const modifier = req.body;
+
+      const repository = new FacilityModifierRepository(facilityId);
+      await repository.setModifier(
+        modifierKey as ModifiersKey,
+        modifier as ModifiersValues
+      );
+
+      res.json({ success: true });
+    } catch (e) {
+      next(e);
+    }
+  }
 }
 
 export default new FacilityController();

--- a/src/exceptions/ApiError.ts
+++ b/src/exceptions/ApiError.ts
@@ -14,11 +14,15 @@ export default class ApiError extends Error {
     return new ApiError(401, 'User is not authorized');
   }
 
-  static BadRequest(message, errors: ValidationError[] = []) {
+  static BadRequest(message: string, errors: ValidationError[] = []) {
     return new ApiError(400, message, errors);
   }
 
   static AccessDenied() {
     return new ApiError(403, 'Access denied');
+  }
+
+  static NotFound(message: string) {
+    return new ApiError(404, message || 'Not Found');
   }
 }

--- a/src/repositories/FacilityModifierRepository.ts
+++ b/src/repositories/FacilityModifierRepository.ts
@@ -1,0 +1,45 @@
+import { AbstractSublevel } from 'abstract-level';
+import DBService, {
+  LevelDefaultTyping,
+  DBLevel,
+  FacilityValues,
+  ModifiersKey,
+  ModifiersValues
+} from '../services/DBService';
+
+export class FacilityModifierRepository {
+  private dbService: DBService;
+  private db: AbstractSublevel<
+    AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
+    LevelDefaultTyping,
+    ModifiersKey,
+    ModifiersValues
+  >;
+
+  constructor(facilityId: string) {
+    this.dbService = DBService.getInstance();
+    this.db = this.dbService.getFacilityModifiersDB(facilityId);
+  }
+
+  public async getModifier(key: ModifiersKey): Promise<ModifiersValues> {
+    try {
+      return await this.db.get(key);
+    } catch (e) {
+      if (e.status === 404) {
+        throw new Error(`Unable to get "${key}" of modifier level"`);
+      }
+      throw e;
+    }
+  }
+
+  public async setModifier(
+    key: ModifiersKey,
+    value: ModifiersValues
+  ): Promise<void> {
+    await this.db.put(key, value);
+  }
+
+  public async delModifier(key: ModifiersKey): Promise<void> {
+    await this.db.del(key);
+  }
+}

--- a/src/repositories/FacilityModifierRepository.ts
+++ b/src/repositories/FacilityModifierRepository.ts
@@ -1,4 +1,5 @@
 import { AbstractSublevel } from 'abstract-level';
+import ApiError from '../exceptions/ApiError';
 import DBService, {
   LevelDefaultTyping,
   DBLevel,
@@ -26,7 +27,7 @@ export class FacilityModifierRepository {
       return await this.db.get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw new Error(`Unable to get "${key}" of modifier level"`);
+        throw ApiError.NotFound(`Unable to get "${key}" of modifier level"`);
       }
       throw e;
     }

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -6,6 +6,7 @@ import DBService, {
 } from '../services/DBService';
 import { Level } from 'level';
 import { Item } from '../proto/facility';
+import ApiError from '../exceptions/ApiError';
 
 export class FacilityRepository {
   private dbService: DBService;
@@ -72,7 +73,7 @@ export class FacilityRepository {
       return await this.dbService.getFacilityDB(facilityId).get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw new Error(`Unable to get "${key}" of facility "${facilityId}"`);
+        throw ApiError.NotFound(`Unable to get "${key}" of facility "${facilityId}"`);
       }
       throw e;
     }
@@ -156,7 +157,7 @@ export class FacilityRepository {
         .get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw new Error(
+        throw ApiError.NotFound(
           `Unable to get "${key}" of item "${itemId}" of facility "${facilityId}"`
         );
       }

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -73,7 +73,9 @@ export class FacilityRepository {
       return await this.dbService.getFacilityDB(facilityId).get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw ApiError.NotFound(`Unable to get "${key}" of facility "${facilityId}"`);
+        throw ApiError.NotFound(
+          `Unable to get "${key}" of facility "${facilityId}"`
+        );
       }
       throw e;
     }

--- a/src/repositories/ItemModifierRegistry.ts
+++ b/src/repositories/ItemModifierRegistry.ts
@@ -1,4 +1,5 @@
 import { AbstractSublevel } from 'abstract-level';
+import ApiError from '../exceptions/ApiError';
 import DBService, {
   DBLevel,
   LevelDefaultTyping,
@@ -33,7 +34,7 @@ export class ItemModifierRepository {
       return await this.db.get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw new Error(`Unable to get "${key}" of modifier level"`);
+        throw ApiError.NotFound(`Unable to get "${key}" of modifier level"`);
       }
       throw e;
     }

--- a/src/repositories/ItemModifierRegistry.ts
+++ b/src/repositories/ItemModifierRegistry.ts
@@ -1,0 +1,64 @@
+import { AbstractSublevel } from 'abstract-level';
+import DBService, {
+  DBLevel,
+  LevelDefaultTyping,
+  FacilityItemValues,
+  FacilityValues,
+  FacilityIndexKey,
+  ModifiersKey,
+  ModifiersValues
+} from '../services/DBService';
+
+export class ItemModifierRepository {
+  private dbService: DBService;
+  private db: AbstractSublevel<
+    AbstractSublevel<
+      AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
+      LevelDefaultTyping,
+      string,
+      FacilityItemValues
+    >,
+    LevelDefaultTyping,
+    ModifiersKey,
+    ModifiersValues
+  >;
+
+  constructor(facilityId: string, indexKey: FacilityIndexKey, itemId: string) {
+    this.dbService = DBService.getInstance();
+    this.db = this.dbService.getItemModifiersDB(facilityId, indexKey, itemId);
+  }
+
+  public async getModifier(key: ModifiersKey): Promise<ModifiersValues> {
+    try {
+      return await this.db.get(key);
+    } catch (e) {
+      if (e.status === 404) {
+        throw new Error(`Unable to get "${key}" of modifier level"`);
+      }
+      throw e;
+    }
+  }
+
+  public async setModifier(
+    key: ModifiersKey,
+    value: ModifiersValues
+  ): Promise<void> {
+    await this.db.put(key, value);
+  }
+
+  public async delModifier(key: ModifiersKey): Promise<void> {
+    await this.db.del(key);
+  }
+}
+
+export class SpaceModifierRepository extends ItemModifierRepository {
+  constructor(facilityId: string, spaceId: string) {
+    super(facilityId, 'spaces', spaceId);
+  }
+}
+
+export class OtherItemsModifierRepository extends ItemModifierRepository {
+  constructor(facilityId: string, otherItemId: string) {
+    super(facilityId, 'otherItems', otherItemId);
+  }
+}

--- a/src/repositories/StubRepository.ts
+++ b/src/repositories/StubRepository.ts
@@ -8,6 +8,7 @@ import DBService, {
 } from '../services/DBService';
 import { AbstractSublevel } from 'abstract-level';
 import { StubStorage } from '../proto/lpms';
+import ApiError from '../exceptions/ApiError';
 
 export class StubRepository {
   private dbService: DBService;
@@ -30,7 +31,7 @@ export class StubRepository {
       return await this.db.get(key);
     } catch (e) {
       if (e.status === 404) {
-        throw new Error(`Unable to get "${key}" of stub level"`);
+        throw ApiError.NotFound(`Unable to get "${key}" of stub level"`);
       }
       throw e;
     }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -640,3 +640,68 @@ router.post(
   authMiddleware,
   facilityController.createFacilityModifier
 );
+
+/**
+ * @swagger
+ * /facility/{facilityId}/{itemKey}/{itemId}/modifier/{modifierKey}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: add modifier to the facility
+ *     tags: [Facility service, availability]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             # @todo Add definition of DayOfWeekRateModifer, OccupancyRateModifier, LOSRateModifier
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: itemKey
+ *         description: Type of item
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["spaces", "otherItems"]
+ *       - in: path
+ *         name: itemId
+ *         description: The item Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       500:
+ *         description: Some server error
+ */
+ router.post(
+  '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.createItemModifier
+);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -596,7 +596,7 @@ router.get(
  *     security:
  *       - bearerAuth: []
  *     summary: add modifier to the facility
- *     tags: [Facility service, availability]
+ *     tags: [Facility service, modifiers]
  *     requestBody:
  *       required: true
  *       content:
@@ -632,6 +632,8 @@ router.get(
  *         description: User is not Auth
  *       403:
  *         description: Access denied
+ *       404:
+ *         description: Not Found
  *       500:
  *         description: Some server error
  */
@@ -648,7 +650,7 @@ router.post(
  *     security:
  *       - bearerAuth: []
  *     summary: add modifier to the facility
- *     tags: [Facility service, availability]
+ *     tags: [Facility service, modifiers]
  *     requestBody:
  *       required: true
  *       content:
@@ -697,6 +699,8 @@ router.post(
  *         description: User is not Auth
  *       403:
  *         description: Access denied
+ *       404:
+ *         description: Not Found
  *       500:
  *         description: Some server error
  */
@@ -704,4 +708,111 @@ router.post(
   '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
   authMiddleware,
   facilityController.createItemModifier
+);
+
+/**
+ * @swagger
+ * /facility/{facilityId}/modifier/{modifierKey}:
+ *   delete:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: remove modifier from the facility
+ *     tags: [Facility service, modifiers]
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Some server error
+ */
+ router.delete(
+  '/facility/:facilityId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.removeModifierOfFacility
+);
+
+/**
+ * @swagger
+ * /facility/{facilityId}/{itemKey}/{itemId}/modifier/{modifierKey}:
+ *   delete:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: remove modifier of the item kind of space or otherItems
+ *     tags: [Facility service, modifiers]
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: itemKey
+ *         description: Type of item
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["spaces", "otherItems"]
+ *       - in: path
+ *         name: itemId
+ *         description: The item Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Some server error
+ */
+ router.delete(
+  '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.removeModifierOfItem
 );

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -323,7 +323,7 @@ export default router;
  *     security:
  *       - bearerAuth: []
  *     summary: get availability by date
- *     tags: [Facility service]
+ *     tags: [Facility service, availability]
  *     parameters:
  *       - in: path
  *         name: facilityId
@@ -357,6 +357,8 @@ export default router;
  *         description: User is not Auth
  *       403:
  *         description: Access denied
+ *       404:
+ *         description: Not Found
  *       500:
  *         description: Some server error
  */
@@ -373,7 +375,7 @@ router.get(
  *     security:
  *       - bearerAuth: []
  *     summary: add availability of the space at date
- *     tags: [Facility service]
+ *     tags: [Facility service, availability]
  *     requestBody:
  *       required: true
  *       content:
@@ -435,7 +437,7 @@ router.post(
  *     security:
  *       - bearerAuth: []
  *     summary: add/update default availability of the space
- *     tags: [Facility service]
+ *     tags: [Facility service, availability]
  *     requestBody:
  *       required: true
  *       content:
@@ -482,4 +484,107 @@ router.post(
   '/facility/:facilityId/space/:spaceId/availability',
   authMiddleware,
   facilityController.createDefaultSpaceAvailability
+);
+
+/**
+ * @swagger
+ * /facility/{facilityId}/modifier/{modifierKey}:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: get modifier of the facility
+ *     tags: [Facility service, modifiers]
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               # @todo Add definition of DayOfWeekRateModifer, OccupancyRateModifier, LOSRateModifier
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Some server error
+ */
+router.get(
+  '/facility/:facilityId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.getModifierOfFacility
+);
+
+/**
+ * @swagger
+ * /facility/{facilityId}/{itemKey}/{itemId}/modifier/{modifierKey}:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: get modifier of the item kind of space or otherItems
+ *     tags: [Facility service, modifiers]
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: itemKey
+ *         description: Type of item
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["spaces", "otherItems"]
+ *       - in: path
+ *         name: itemId
+ *         description: The item Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               # @todo Add definition of DayOfWeekRateModifer, OccupancyRateModifier, LOSRateModifier
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Some server error
+ */
+router.get(
+  '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.getModifierOfItem
 );

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -704,7 +704,7 @@ router.post(
  *       500:
  *         description: Some server error
  */
- router.post(
+router.post(
   '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
   authMiddleware,
   facilityController.createItemModifier
@@ -751,7 +751,7 @@ router.post(
  *       500:
  *         description: Some server error
  */
- router.delete(
+router.delete(
   '/facility/:facilityId/modifier/:modifierKey',
   authMiddleware,
   facilityController.removeModifierOfFacility
@@ -811,7 +811,7 @@ router.post(
  *       500:
  *         description: Some server error
  */
- router.delete(
+router.delete(
   '/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey',
   authMiddleware,
   facilityController.removeModifierOfItem

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -588,3 +588,55 @@ router.get(
   authMiddleware,
   facilityController.getModifierOfItem
 );
+
+/**
+ * @swagger
+ * /facility/{facilityId}/modifier/{modifierKey}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: add modifier to the facility
+ *     tags: [Facility service, availability]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             # @todo Add definition of DayOfWeekRateModifer, OccupancyRateModifier, LOSRateModifier
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         description: The facility Id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: modifierKey
+ *         description: The facility modifier key
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: ["day_of_week", "occupancy", "length_of_stay"]
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: User is not Auth
+ *       403:
+ *         description: Access denied
+ *       500:
+ *         description: Some server error
+ */
+router.post(
+  '/facility/:facilityId/modifier/:modifierKey',
+  authMiddleware,
+  facilityController.createFacilityModifier
+);

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -183,7 +183,11 @@ export default class DBService {
     >('stubs', { valueEncoding: 'json' });
   }
 
-  public getItemModifiersDB(facilityId: string, indexKey: FacilityIndexKey, itemId: string) {
+  public getItemModifiersDB(
+    facilityId: string,
+    indexKey: FacilityIndexKey,
+    itemId: string
+  ) {
     return this.getFacilityItemDB(facilityId, indexKey, itemId).sublevel<
       ModifiersKey,
       ModifiersValues

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -16,7 +16,6 @@ import {
   Rates,
   StubStorage
 } from '../proto/lpms';
-import { Stub } from '../proto/stub';
 import { Person } from '../proto/person';
 
 export type LevelDefaultTyping = string | Buffer | Uint8Array;
@@ -177,17 +176,17 @@ export default class DBService {
     >('rules', { valueEncoding: 'json' });
   }
 
-  public getSpaceModifiersDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
-      ModifiersKey,
-      ModifiersValues
-    >('modifiers', { valueEncoding: 'json' });
-  }
-
   public getSpaceStubsDB(facilityId: string, spaceId: string) {
     return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
       SpaceStubKey,
       SpaceStubValues
     >('stubs', { valueEncoding: 'json' });
+  }
+
+  public getItemModifiersDB(facilityId: string, indexKey: FacilityIndexKey, itemId: string) {
+    return this.getFacilityItemDB(facilityId, indexKey, itemId).sublevel<
+      ModifiersKey,
+      ModifiersValues
+    >('modifiers', { valueEncoding: 'json' });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,18 +1639,18 @@
   resolved "https://registry.yarnpkg.com/@web3-storage/parse-link-header/-/parse-link-header-3.1.0.tgz#4562724987649dd6d3e07c87be1826804d212ef7"
   integrity sha512-K1undnK70vLLauqdE8bq/l98isTF2FDhcP0UPpXVSjkSWe3xhAn5eRXk5jfA1E5ycNm84Ws/rQFUD7ue11nciw==
 
-"@windingtree/stays-models@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@windingtree/stays-models/-/stays-models-2.0.0.tgz#5399baca2618cc3bda65361bff179a5d3e162f5b"
-  integrity sha512-PhO/eX3FireIN3tcQFMQBJ6b+Z4fgGXtrmvAbBqKj2Ouasf0FB/+yQmyFy8jl2cFJpUF1H7dgpspfsFaJaBHJA==
+"@windingtree/stays-models@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@windingtree/stays-models/-/stays-models-2.0.1.tgz#27e3bdb0907fefbdff1577c112ade3d37d85ca52"
+  integrity sha512-idvgsYvXsjUMNf3LH6XAZinH676EDVXA+t3txDxkWY5vlikFhw3kmrMD63QjgQjHoXhMikYM8r08AXsZD1YU5w==
   dependencies:
     "@protobuf-ts/runtime" "^2.6.0"
     zlib "^1.0.5"
 
-"@windingtree/videre-contracts@^0.2.0-alpha.1":
-  version "0.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-0.2.0-alpha.1.tgz#94c2f5a350e775f9d0c82364c51a5f7c02808aea"
-  integrity sha512-51q0tgv2gzOyGNob8NhlTUZaSWMempNX2vN+IB3JDSnl8UqUFpvsZRMI1iji9IVzjFMA9ZfhiQ3RZD6rfb+6VQ==
+"@windingtree/videre-contracts@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@windingtree/videre-contracts/-/videre-contracts-1.0.2.tgz#a78b813dfae7d393e8f297213a6479f7e67213fb"
+  integrity sha512-Owrl1uP4xEqODi0ID0I8BsDG4MGBTBZDKUtlTbBlKsZn67DyNc7FU0V0HB8IDTmtLvQ3le7l1oD317i4TmFG7Q==
   dependencies:
     "@openzeppelin/contracts" "^4.5.0"
 


### PR DESCRIPTION
This PR adds:

- `FacilityModifierRepository`, `ItemModifierRepository` connectors
- API endpoints for adding modifiers to `Facilities` and `Items` (`spaces` or `otherItems`)
    - GET: `/facility/:facilityId/modifier/:modifierKey`
    - GET: `/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey`
    - POST: `/facility/:facilityId/modifier/:modifierKey`
    - POST: `/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey`
    - DELETE: `/facility/:facilityId/modifier/:modifierKey`
    - DELETE: `/facility/:facilityId/:itemKey/:itemId/modifier/:modifierKey`
- `NotFound` utility added to the `ApiError`
- minor refactoring of controllers

Closes:

- #18
- #13