### PR TITLE
Guard protobuf message decoding and EIP-712 signing

### DIFF
--- a/src/controllers/StorageController.ts
+++ b/src/controllers/StorageController.ts
@@ -12,7 +12,7 @@ import { web3StorageKey, lineRegistryDataDomain } from '../config';
 import { walletAccountsIndexes } from '../types';
 import { Facility, Item, ItemType, Space } from '../proto/facility';
 import facilityService from '../services/FacilityService';
-import { FacilitySpaceValues } from 'src/services/DBService';
+import { FacilitySpaceValues } from '../services/DBService';
 const { readFile } = promises;
 
 export class StorageController {

--- a/src/services/PingPongService.ts
+++ b/src/services/PingPongService.ts
@@ -4,14 +4,22 @@ import log from './LogService';
 import WalletService from './WalletService';
 import { walletAccountsIndexes } from '../types';
 import { Ping, Pong } from '../proto/pingpong';
+import { Facility as FacilityMetadata } from '../proto/facility';
+import facilityRepository, {
+  FacilityRepository
+} from '../repositories/FacilityRepository';
 
 import { lineRegistryDataDomain, videreConfig } from '../config';
 import { getCurrentTimestamp } from '../utils';
 import { AbstractFacilityService } from './interfaces/AbstractFacilityService';
+import { LatLng } from '../proto/latlng';
 
 export class PingPongService extends AbstractFacilityService {
+  protected facilityRepository: FacilityRepository;
+
   constructor() {
     super();
+    this.facilityRepository = new FacilityRepository();
   }
 
   /**
@@ -32,28 +40,48 @@ export class PingPongService extends AbstractFacilityService {
     const observer = await this.waku.makeWakuObserver(
       async (message) => {
         const msg = this.waku.processMessage(Ping, message);
-        if (msg?.timestamp) {
-          log.green(`Ping received with timestamp: ${msg.timestamp}`);
-        } else {
-          log.yellow(`Ping received at local time: ${getCurrentTimestamp()}`);
-        }
+        if (msg) {
+          if (msg.timestamp) {
+            log.green(`Ping received with timestamp: ${msg.timestamp.seconds}`);
+          } else {
+            log.yellow(`Ping received at local time: ${getCurrentTimestamp()}`);
+          }
 
-        // respond to the ping with a pong
-        this.waku.sendMessage(
-          Pong,
-          await vUtils.createSignedMessage<Pong>(
-            lineRegistryDataDomain,
-            eip712.pingpong.Pong,
-            {
-              serviceProvider: utils.arrayify(facilityId),
-              loc: utils.toUtf8Bytes(h3Index),
-              timestamp: getCurrentTimestamp(),
-              signature: utils.toUtf8Bytes('') // initially blank signature which gets filled in
-            },
-            await WalletService.getWalletByIndex(walletAccountsIndexes.BIDDER)
-          ),
-          vUtils.generateTopic({ ...videreConfig, topic: 'pong' }, h3Index)
-        );
+          try {
+            const metadata = (await facilityRepository.getFacilityKey(
+              facilityId,
+              'metadata'
+            )) as FacilityMetadata;
+
+            if (metadata.location) {
+              // respond to the ping with a pong
+              this.waku.sendMessage(
+                Pong,
+                await vUtils.createSignedMessage<Pong>(
+                  lineRegistryDataDomain,
+                  eip712.pingpong.Pong,
+                  {
+                    serviceProvider: utils.arrayify(facilityId),
+                    loc: LatLng.toBinary(metadata.location),
+                    timestamp: getCurrentTimestamp(),
+                    signature: utils.toUtf8Bytes('') // initially blank signature which gets filled in
+                  },
+                  await WalletService.getWalletByIndex(
+                    walletAccountsIndexes.BIDDER
+                  )
+                ),
+                vUtils.generateTopic(
+                  { ...videreConfig, topic: 'pong' },
+                  h3Index
+                )
+              );
+            }
+          } catch (e) {
+            log.red('Malformed EIP-712 signing' + e);
+          }
+        } else {
+          log.red('Malformed Ping message');
+        }
       },
       [vUtils.generateTopic({ ...videreConfig, topic: 'ping' }, h3Index)]
     );

--- a/src/services/WakuService.ts
+++ b/src/services/WakuService.ts
@@ -64,7 +64,11 @@ export default class WakuService {
     wakuMessage: WakuMessage
   ): T | undefined {
     if (!wakuMessage.payload) return;
-    return protoMessageInstance.fromBinary(wakuMessage.payload);
+    try {
+      return protoMessageInstance.fromBinary(wakuMessage.payload);
+    } catch (e) {
+      return;
+    }
   }
 
   public async makeWakuObserver(


### PR DESCRIPTION
This PR:

- Places try/catch guards around all protobuf message decoding and therefore closes #71
- Places try/catch guards around all EIP-712 signing to protect against malformed messages 
- Now sends a `LatLng` for location in `Pong` response per Stays reference implementation, and therefore closes #70 

✅ Closes: 71, 70