### PR TITLE
Fix missing Item metadata

### DIFF
--- a/src/controllers/FacilityController.ts
+++ b/src/controllers/FacilityController.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
 import {
-  FacilityIndexKey,
   FormattedDate,
   ModifiersKey,
   ModifiersValues,
@@ -21,7 +20,7 @@ import { Facility } from '../proto/facility';
 import { validationResult } from 'express-validator';
 import {
   FacilityRuleRepository,
-  SpaceRuleRepository
+  ItemRuleRepository
 } from '../repositories/RuleRepository';
 import stubService from '../services/StubService';
 
@@ -67,22 +66,12 @@ export class FacilityController {
       const { facilityId } = req.params;
       const { metadata } = req.body;
 
-      const spaces = await facilityService.getFacilityDbKeyValues(
+      const items = await facilityService.getFacilityDbKeyValues(
         facilityId,
-        'spaces'
+        'items'
       );
 
-      const otherItems = await facilityService.getFacilityDbKeyValues(
-        facilityId,
-        'otherItems'
-      );
-
-      await facilityService.saveFacilityMetadata(
-        facilityId,
-        metadata,
-        spaces,
-        otherItems
-      );
+      await facilityService.saveFacilityMetadata(facilityId, metadata, items);
 
       await facilityService.setFacilityDbKeys(facilityId, [
         ['metadata', metadata as Facility]
@@ -240,7 +229,7 @@ export class FacilityController {
     }
   };
 
-  // Returns modifier of the item: `spaces` or `otherItems`
+  // Returns modifier of the item
   getModifierOfItem = async (
     req: Request,
     res: Response,
@@ -253,11 +242,7 @@ export class FacilityController {
       }
       const { facilityId, itemKey, itemId, modifierKey } = req.params;
 
-      const repository = new ItemModifierRepository(
-        facilityId,
-        itemKey as FacilityIndexKey,
-        itemId
-      );
+      const repository = new ItemModifierRepository(facilityId, itemId);
 
       let modifier = await repository.getModifier(modifierKey as ModifiersKey);
 
@@ -307,7 +292,7 @@ export class FacilityController {
     }
   };
 
-  // Creates a modifier for the item: spaces or otherItems
+  // Creates a modifier for the item
   createItemModifier = async (
     req: Request,
     res: Response,
@@ -318,14 +303,10 @@ export class FacilityController {
       if (!errors.isEmpty()) {
         return next(ApiError.BadRequest('Validation error', errors.array()));
       }
-      const { facilityId, itemKey, itemId, modifierKey } = req.params;
+      const { facilityId, itemId, modifierKey } = req.params;
       const modifier = req.body;
 
-      const repository = new ItemModifierRepository(
-        facilityId,
-        itemKey as FacilityIndexKey,
-        itemId
-      );
+      const repository = new ItemModifierRepository(facilityId, itemId);
 
       await repository.setModifier(
         modifierKey as ModifiersKey,
@@ -360,7 +341,7 @@ export class FacilityController {
     }
   };
 
-  // Removes modifier of the item: `spaces` or `otherItems`
+  // Removes modifier of the item
   removeModifierOfItem = async (
     req: Request,
     res: Response,
@@ -371,13 +352,9 @@ export class FacilityController {
       if (!errors.isEmpty()) {
         return next(ApiError.BadRequest('Validation error', errors.array()));
       }
-      const { facilityId, itemKey, itemId, modifierKey } = req.params;
+      const { facilityId, itemId, modifierKey } = req.params;
 
-      const repository = new ItemModifierRepository(
-        facilityId,
-        itemKey as FacilityIndexKey,
-        itemId
-      );
+      const repository = new ItemModifierRepository(facilityId, itemId);
 
       await repository.delModifier(modifierKey as ModifiersKey);
 
@@ -415,7 +392,7 @@ export class FacilityController {
     }
   };
 
-  // Returns rule of the item: `spaces` or `otherItems`
+  // Returns rule of the item
   getRuleOfItem = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const errors = validationResult(req);
@@ -424,7 +401,7 @@ export class FacilityController {
       }
       const { facilityId, itemId, ruleKey } = req.params;
 
-      const repository = new SpaceRuleRepository(facilityId, itemId);
+      const repository = new ItemRuleRepository(facilityId, itemId);
 
       const rule = await repository.getRule(ruleKey as RulesItemKey);
 
@@ -464,7 +441,7 @@ export class FacilityController {
     }
   };
 
-  // Creates a rule for the item: spaces or otherItems
+  // Creates a rule for the item
   createItemRule = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const errors = validationResult(req);
@@ -474,7 +451,7 @@ export class FacilityController {
       const { facilityId, itemId, ruleKey } = req.params;
       const rule = req.body;
 
-      const repository = new SpaceRuleRepository(facilityId, itemId);
+      const repository = new ItemRuleRepository(facilityId, itemId);
 
       await repository.setRule(ruleKey as RulesItemKey, rule as Rules);
 
@@ -506,7 +483,7 @@ export class FacilityController {
     }
   };
 
-  // Removes rule of the item: `spaces` or `otherItems`
+  // Removes rule of the item
   delRuleOfItem = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const errors = validationResult(req);
@@ -515,7 +492,7 @@ export class FacilityController {
       }
       const { facilityId, itemId, ruleKey } = req.params;
 
-      const repository = new SpaceRuleRepository(facilityId, itemId);
+      const repository = new ItemRuleRepository(facilityId, itemId);
 
       await repository.delRule(ruleKey as RulesItemKey);
 

--- a/src/controllers/FacilityItemController.ts
+++ b/src/controllers/FacilityItemController.ts
@@ -2,9 +2,9 @@ import type { NextFunction, Request, Response } from 'express';
 import ApiError from '../exceptions/ApiError';
 import facilityService from '../services/FacilityService';
 import facilityRepository from '../repositories/FacilityRepository';
-import { Space } from '../proto/facility';
+import { Item } from '../proto/facility';
 import { validationResult } from 'express-validator';
-import { FacilityIndexKey } from '../services/DBService';
+import { FacilitySubLevels } from '../services/DBService';
 import stubService from '../services/StubService';
 
 export class FacilityItemController {
@@ -13,7 +13,7 @@ export class FacilityItemController {
       const { facilityId, itemKey } = req.params;
       const items = await facilityService.getFacilityDbKeyValues(
         facilityId,
-        itemKey as FacilityIndexKey
+        itemKey as FacilitySubLevels
       );
 
       return res.json(items);
@@ -29,9 +29,9 @@ export class FacilityItemController {
         return next(ApiError.BadRequest('Validation error', errors.array()));
       }
       const { facilityId, itemKey, itemId } = req.params;
-      const item = await facilityRepository.getItemKey<Space>(
+      const item = await facilityRepository.getItemKey<Item>(
         facilityId,
-        itemKey as FacilityIndexKey,
+        itemKey as FacilitySubLevels,
         itemId,
         'metadata'
       );
@@ -56,9 +56,9 @@ export class FacilityItemController {
       const { metadata } = req.body;
 
       if (
-        await facilityRepository.getItemKey<Space>(
+        await facilityRepository.getItemKey<Item>(
           facilityId,
-          itemKey as FacilityIndexKey,
+          itemKey as FacilitySubLevels,
           itemId,
           'metadata'
         )
@@ -70,7 +70,7 @@ export class FacilityItemController {
 
       await facilityService.setItemDbKeys(
         facilityId,
-        itemKey as FacilityIndexKey,
+        itemKey as FacilitySubLevels,
         itemId,
         [['metadata', metadata]]
       );
@@ -92,9 +92,9 @@ export class FacilityItemController {
       const { metadata } = req.body;
 
       if (
-        !(await facilityRepository.getItemKey<Space>(
+        !(await facilityRepository.getItemKey<Item>(
           facilityId,
-          itemKey as FacilityIndexKey,
+          itemKey as FacilitySubLevels,
           itemId,
           'metadata'
         ))
@@ -106,7 +106,7 @@ export class FacilityItemController {
 
       await facilityService.setItemDbKeys(
         facilityId,
-        itemKey as FacilityIndexKey,
+        itemKey as FacilitySubLevels,
         itemId,
         [['metadata', metadata]]
       );
@@ -127,9 +127,9 @@ export class FacilityItemController {
       const { facilityId, itemKey, itemId } = req.params;
 
       if (
-        !(await facilityRepository.getItemKey<Space>(
+        !(await facilityRepository.getItemKey<Item>(
           facilityId,
-          itemKey as FacilityIndexKey,
+          itemKey as FacilitySubLevels,
           itemId,
           'metadata'
         ))
@@ -141,7 +141,7 @@ export class FacilityItemController {
 
       await facilityService.delItemMetadata(
         facilityId,
-        itemKey as FacilityIndexKey,
+        itemKey as FacilitySubLevels,
         itemId
       );
 

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -96,7 +96,7 @@ export class FacilityRepository {
 
   public async setFacilityKey(
     facilityId: string,
-    key: FacilityKey | FacilitySubLevels,
+    key: FacilityKey | FacilityIndexKey,
     value: FacilityValues
   ): Promise<void> {
     await this.dbService.getFacilityDB(facilityId).put(key, value);
@@ -104,7 +104,7 @@ export class FacilityRepository {
 
   public async getFacilityKey<T extends FacilityValues>(
     facilityId: string,
-    key: FacilityKey | FacilitySubLevels
+    key: FacilityKey | FacilityIndexKey
   ): Promise<T | null> {
     try {
       return (await this.dbService.getFacilityDB(facilityId).get(key)) as T;
@@ -118,7 +118,7 @@ export class FacilityRepository {
 
   public async delFacilityKey(
     facilityId: string,
-    key: FacilityKey | FacilitySubLevels
+    key: FacilityKey | FacilityIndexKey
   ): Promise<void> {
     await this.dbService.getFacilityDB(facilityId).del(key);
   }

--- a/src/repositories/FacilityRepository.ts
+++ b/src/repositories/FacilityRepository.ts
@@ -1,8 +1,8 @@
 import DBService, {
   FacilityKey,
+  FacilitySubLevels,
   FacilityIndexKey,
-  FacilityValues,
-  FacilitySpaceValues
+  FacilityValues
 } from '../services/DBService';
 import { Level } from 'level';
 import { Item } from '../proto/facility';
@@ -96,7 +96,7 @@ export class FacilityRepository {
 
   public async setFacilityKey(
     facilityId: string,
-    key: FacilityKey | FacilityIndexKey,
+    key: FacilityKey | FacilitySubLevels,
     value: FacilityValues
   ): Promise<void> {
     await this.dbService.getFacilityDB(facilityId).put(key, value);
@@ -104,7 +104,7 @@ export class FacilityRepository {
 
   public async getFacilityKey<T extends FacilityValues>(
     facilityId: string,
-    key: FacilityKey | FacilityIndexKey
+    key: FacilityKey | FacilitySubLevels
   ): Promise<T | null> {
     try {
       return (await this.dbService.getFacilityDB(facilityId).get(key)) as T;
@@ -118,7 +118,7 @@ export class FacilityRepository {
 
   public async delFacilityKey(
     facilityId: string,
-    key: FacilityKey | FacilityIndexKey
+    key: FacilityKey | FacilitySubLevels
   ): Promise<void> {
     await this.dbService.getFacilityDB(facilityId).del(key);
   }
@@ -179,23 +179,23 @@ export class FacilityRepository {
     }
   }
 
-  // --- item level (space and otherItems) getters / setters
+  // --- item level getters / setters
 
   public async setItemKey(
     facilityId: string,
-    idx: FacilityIndexKey,
+    idx: FacilitySubLevels,
     itemId: string,
     key: string,
-    value: Item | FacilitySpaceValues
+    value: Item
   ): Promise<void> {
     await this.dbService
       .getFacilityItemDB(facilityId, idx, itemId)
       .put(key, value);
   }
 
-  public async getItemKey<T extends Item | FacilitySpaceValues>(
+  public async getItemKey<T extends Item>(
     facilityId: string,
-    idx: FacilityIndexKey,
+    idx: FacilitySubLevels,
     itemId: string,
     key: string
   ): Promise<T | null> {
@@ -213,7 +213,7 @@ export class FacilityRepository {
 
   public async delItemKey(
     facilityId: string,
-    idx: FacilityIndexKey,
+    idx: FacilitySubLevels,
     itemId: string,
     key: string
   ): Promise<void> {

--- a/src/repositories/ItemRateRepository.ts
+++ b/src/repositories/ItemRateRepository.ts
@@ -1,13 +1,13 @@
 import DBService, {
   DBLevel,
   DefaultOrDateItemKey,
-  FacilityItemValues,
   FacilityValues,
   FormattedDate,
   LevelDefaultTyping
 } from '../services/DBService';
 import { AbstractSublevel } from 'abstract-level';
 import { Rates } from '../proto/lpms';
+import { Item as ItemMetadata } from '../proto/facility';
 
 export class ItemRateRepository {
   protected dbService = DBService.getInstance();
@@ -16,7 +16,7 @@ export class ItemRateRepository {
       AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
       LevelDefaultTyping,
       string,
-      FacilityItemValues
+      ItemMetadata
     >,
     LevelDefaultTyping,
     DefaultOrDateItemKey,

--- a/src/repositories/ItemRateRepository.ts
+++ b/src/repositories/ItemRateRepository.ts
@@ -23,7 +23,7 @@ export class ItemRateRepository {
     Rates
   >;
 
-  protected constructor(facilityId: string, itemId: string) {
+  constructor(facilityId: string, itemId: string) {
     this.db = this.dbService.getItemRatesDB(facilityId, 'items', itemId);
   }
 

--- a/src/repositories/ItemRateRepository.ts
+++ b/src/repositories/ItemRateRepository.ts
@@ -1,7 +1,6 @@
 import DBService, {
   DBLevel,
   DefaultOrDateItemKey,
-  FacilityIndexKey,
   FacilityItemValues,
   FacilityValues,
   FormattedDate,
@@ -10,7 +9,7 @@ import DBService, {
 import { AbstractSublevel } from 'abstract-level';
 import { Rates } from '../proto/lpms';
 
-abstract class ItemRateRepository {
+export class ItemRateRepository {
   protected dbService = DBService.getInstance();
   protected db: AbstractSublevel<
     AbstractSublevel<
@@ -24,12 +23,8 @@ abstract class ItemRateRepository {
     Rates
   >;
 
-  protected constructor(
-    facilityId: string,
-    indexKey: FacilityIndexKey,
-    itemId: string
-  ) {
-    this.db = this.dbService.getItemRatesDB(facilityId, indexKey, itemId);
+  protected constructor(facilityId: string, itemId: string) {
+    this.db = this.dbService.getItemRatesDB(facilityId, 'items', itemId);
   }
 
   public async getRate(key: DefaultOrDateItemKey): Promise<Rates | null> {
@@ -53,17 +48,5 @@ abstract class ItemRateRepository {
 
   public async delRate(key: DefaultOrDateItemKey): Promise<void> {
     await this.db.del(key);
-  }
-}
-
-export class SpaceRateRepository extends ItemRateRepository {
-  constructor(facilityId: string, itemId: string) {
-    super(facilityId, 'spaces', itemId);
-  }
-}
-
-export class OtherItemRateRepository extends ItemRateRepository {
-  constructor(facilityId: string, itemId: string) {
-    super(facilityId, 'otherItems', itemId);
   }
 }

--- a/src/repositories/ModifierRepository.ts
+++ b/src/repositories/ModifierRepository.ts
@@ -2,11 +2,11 @@ import { AbstractSublevel } from 'abstract-level';
 import DBService, {
   DBLevel,
   LevelDefaultTyping,
-  FacilityItemValues,
   FacilityValues,
   ModifiersKey,
   ModifiersValues
 } from '../services/DBService';
+import { Item as ItemMetadata } from '../proto/facility';
 
 abstract class ModifierRepository {
   protected dbService: DBService = DBService.getInstance();
@@ -43,7 +43,7 @@ export class ItemModifierRepository extends ModifierRepository {
       AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
       LevelDefaultTyping,
       string,
-      FacilityItemValues
+      ItemMetadata
     >,
     LevelDefaultTyping,
     ModifiersKey,

--- a/src/repositories/ModifierRepository.ts
+++ b/src/repositories/ModifierRepository.ts
@@ -4,7 +4,6 @@ import DBService, {
   LevelDefaultTyping,
   FacilityItemValues,
   FacilityValues,
-  FacilityIndexKey,
   ModifiersKey,
   ModifiersValues
 } from '../services/DBService';
@@ -51,10 +50,10 @@ export class ItemModifierRepository extends ModifierRepository {
     ModifiersValues
   >;
 
-  constructor(facilityId: string, indexKey: FacilityIndexKey, itemId: string) {
+  constructor(facilityId: string, itemId: string) {
     super();
 
-    this.db = this.dbService.getItemModifiersDB(facilityId, indexKey, itemId);
+    this.db = this.dbService.getItemModifiersDB(facilityId, 'items', itemId);
   }
 }
 
@@ -70,17 +69,5 @@ export class FacilityModifierRepository extends ModifierRepository {
     super();
 
     this.db = this.dbService.getFacilityModifiersDB(facilityId);
-  }
-}
-
-export class SpaceModifierRepository extends ItemModifierRepository {
-  constructor(facilityId: string, spaceId: string) {
-    super(facilityId, 'spaces', spaceId);
-  }
-}
-
-export class OtherItemsModifierRepository extends ItemModifierRepository {
-  constructor(facilityId: string, otherItemId: string) {
-    super(facilityId, 'otherItems', otherItemId);
   }
 }

--- a/src/repositories/RuleRepository.ts
+++ b/src/repositories/RuleRepository.ts
@@ -1,6 +1,5 @@
 import DBService, {
   DBLevel,
-  FacilityIndexKey,
   FacilityItemValues,
   FacilityValues,
   LevelDefaultTyping,
@@ -33,30 +32,6 @@ abstract class RuleRepository {
   }
 }
 
-abstract class ItemRuleRepository extends RuleRepository {
-  protected db: AbstractSublevel<
-    AbstractSublevel<
-      AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
-      LevelDefaultTyping,
-      string,
-      FacilityItemValues
-    >,
-    LevelDefaultTyping,
-    RulesItemKey,
-    Rules
-  >;
-
-  protected constructor(
-    facilityId: string,
-    indexKey: FacilityIndexKey,
-    itemId: string
-  ) {
-    super();
-
-    this.db = this.dbService.getItemRulesDB(facilityId, indexKey, itemId);
-  }
-}
-
 export class FacilityRuleRepository extends RuleRepository {
   protected db: AbstractSublevel<
     AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
@@ -72,13 +47,22 @@ export class FacilityRuleRepository extends RuleRepository {
   }
 }
 
-export class SpaceRuleRepository extends ItemRuleRepository {
+export class ItemRuleRepository extends RuleRepository {
+  protected db: AbstractSublevel<
+    AbstractSublevel<
+      AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
+      LevelDefaultTyping,
+      string,
+      FacilityItemValues
+    >,
+    LevelDefaultTyping,
+    RulesItemKey,
+    Rules
+  >;
+
   constructor(facilityId: string, itemId: string) {
-    super(facilityId, 'spaces', itemId);
-  }
-}
-export class OtherItemRuleRepository extends ItemRuleRepository {
-  constructor(facilityId: string, itemId: string) {
-    super(facilityId, 'otherItems', itemId);
+    super();
+
+    this.db = this.dbService.getItemRulesDB(facilityId, 'items', itemId);
   }
 }

--- a/src/repositories/RuleRepository.ts
+++ b/src/repositories/RuleRepository.ts
@@ -1,11 +1,11 @@
 import DBService, {
   DBLevel,
-  FacilityItemValues,
   FacilityValues,
   LevelDefaultTyping,
   Rules,
   RulesItemKey
 } from '../services/DBService';
+import { Item as ItemMetadata } from '../proto/facility';
 import { AbstractSublevel } from 'abstract-level';
 
 abstract class RuleRepository {
@@ -53,7 +53,7 @@ export class ItemRuleRepository extends RuleRepository {
       AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
       LevelDefaultTyping,
       string,
-      FacilityItemValues
+      ItemMetadata
     >,
     LevelDefaultTyping,
     RulesItemKey,

--- a/src/repositories/SpaceAvailabilityRepository.ts
+++ b/src/repositories/SpaceAvailabilityRepository.ts
@@ -1,16 +1,16 @@
 import DBService, {
   FormattedDate,
   DefaultOrDateItemKey,
-  FacilityItemValues,
   LevelDefaultTyping
 } from '../services/DBService';
+import { Item as ItemMetadata } from '../proto/facility';
 import { AbstractLevel, AbstractSublevel } from 'abstract-level';
 import { Availability } from '../proto/lpms';
 
 export class SpaceAvailabilityRepository {
   private dbService: DBService;
   private db: AbstractSublevel<
-    AbstractLevel<LevelDefaultTyping, string, FacilityItemValues>,
+    AbstractLevel<LevelDefaultTyping, string, ItemMetadata>,
     LevelDefaultTyping,
     DefaultOrDateItemKey,
     Availability

--- a/src/repositories/SpaceStubRepository.ts
+++ b/src/repositories/SpaceStubRepository.ts
@@ -1,11 +1,11 @@
 import {
-  FacilityItemValues,
   LevelDefaultTyping,
   DBLevel,
   FacilityValues,
   SpaceStubKey,
   SpaceStubValues
 } from '../services/DBService';
+import { Item as ItemMetadata } from '../proto/facility';
 import { AbstractSublevel } from 'abstract-level';
 import { AbstractStubRepository } from './StubRepository';
 
@@ -15,7 +15,7 @@ export class SpaceStubRepository extends AbstractStubRepository {
       AbstractSublevel<DBLevel, LevelDefaultTyping, string, FacilityValues>,
       LevelDefaultTyping,
       string,
-      FacilityItemValues
+      ItemMetadata
     >,
     LevelDefaultTyping,
     SpaceStubKey,

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -34,7 +34,8 @@ export type ModifiersValues =
   | LOSRateModifier;
 export type ModifiersKey = 'day_of_week' | 'occupancy' | 'length_of_stay';
 export type FacilityKey = 'metadata';
-export type FacilityIndexKey = 'stubs' | 'spaces' | 'otherItems';
+export type FacilitySubLevels = 'stubs' | 'items';
+export type FacilityIndexKey = FacilitySubLevels | 'spaces';
 export type FacilityValues = FacilityMetadata | string[];
 export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
 export type FacilityItemValues = ItemMetadata | FacilitySpaceValues;
@@ -156,14 +157,14 @@ export default class DBService {
   }
 
   public getSpaceAvailabilityDB(facilityId: string, itemId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', itemId).sublevel<
+    return this.getFacilityItemDB(facilityId, 'items', itemId).sublevel<
       DefaultOrDateItemKey,
       Availability
     >('availability', { valueEncoding: 'json' });
   }
 
-  public getSpaceStubsDB(facilityId: string, spaceId: string) {
-    return this.getFacilityItemDB(facilityId, 'spaces', spaceId).sublevel<
+  public getSpaceStubsDB(facilityId: string, itemId: string) {
+    return this.getFacilityItemDB(facilityId, 'items', itemId).sublevel<
       SpaceStubKey,
       SpaceStubValues
     >('stubs', { valueEncoding: 'json' });

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -36,7 +36,6 @@ export type FacilityKey = 'metadata';
 export type FacilitySubLevels = 'stubs' | 'items';
 export type FacilityIndexKey = FacilitySubLevels | 'spaces';
 export type FacilityValues = FacilityMetadata | string[];
-export type FacilityItemValues = ItemMetadata;
 export type FormattedDate = `${number}-${number}-${number}`;
 export type DefaultOrDateItemKey = 'default' | FormattedDate;
 export type FacilityStubKey = string | FormattedDate;
@@ -121,10 +120,9 @@ export default class DBService {
     itemId: string
   ) {
     const key = `${itemType}_${itemId}`;
-    return this.getFacilityDB(facilityId).sublevel<string, FacilityItemValues>(
-      key,
-      { valueEncoding: 'json' }
-    );
+    return this.getFacilityDB(facilityId).sublevel<string, ItemMetadata>(key, {
+      valueEncoding: 'json'
+    });
   }
 
   public getFacilityRulesDB(facilityId: string) {

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -3,8 +3,7 @@ import { Level } from 'level';
 import { Token, User } from '../types';
 import {
   Facility as FacilityMetadata,
-  Item as ItemMetadata,
-  Space as SpaceMetadata
+  Item as ItemMetadata
 } from '../proto/facility';
 import {
   Availability,
@@ -37,8 +36,7 @@ export type FacilityKey = 'metadata';
 export type FacilitySubLevels = 'stubs' | 'items';
 export type FacilityIndexKey = FacilitySubLevels | 'spaces';
 export type FacilityValues = FacilityMetadata | string[];
-export type FacilitySpaceValues = ItemMetadata | SpaceMetadata;
-export type FacilityItemValues = ItemMetadata | FacilitySpaceValues;
+export type FacilityItemValues = ItemMetadata;
 export type FormattedDate = `${number}-${number}-${number}`;
 export type DefaultOrDateItemKey = 'default' | FormattedDate;
 export type FacilityStubKey = string | FormattedDate;

--- a/src/services/QuoteService.ts
+++ b/src/services/QuoteService.ts
@@ -10,15 +10,15 @@ import {
   LOSRateModifier,
   OccupancyRateModifier
 } from '../proto/lpms';
-import { SpaceRateRepository } from '../repositories/ItemRateRepository';
+import { ItemRateRepository } from '../repositories/ItemRateRepository';
 import {
   FacilityModifierRepository,
-  SpaceModifierRepository
+  ItemModifierRepository
 } from '../repositories/ModifierRepository';
 
 export interface QuoteRepositories {
-  rates: SpaceRateRepository;
-  modifiers: SpaceModifierRepository;
+  rates: ItemRateRepository;
+  modifiers: ItemModifierRepository;
   facilityModifiers: FacilityModifierRepository;
 }
 
@@ -210,8 +210,8 @@ export class QuoteService {
     }
 
     const repositories: QuoteRepositories = {
-      rates: new SpaceRateRepository(facilityId, spaceId),
-      modifiers: new SpaceModifierRepository(facilityId, spaceId),
+      rates: new ItemRateRepository(facilityId, spaceId),
+      modifiers: new ItemModifierRepository(facilityId, spaceId),
       facilityModifiers: new FacilityModifierRepository(facilityId)
     };
     let total = BigNumber.from(0);

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,4 +1,11 @@
-import { Exception, Facility, Space, SpaceTier } from '../src/proto/facility';
+import {
+  Exception,
+  Facility,
+  Item,
+  ItemType,
+  Space,
+  SpaceTier
+} from '../src/proto/facility';
 import { ContactType } from '../src/proto/contact';
 
 export const facility: Facility = {
@@ -69,87 +76,96 @@ export const facility: Facility = {
   }
 };
 
-export const space: Space = {
-  uris: [
-    {
-      uri: 'https://wonderland.somewhere/',
-      typeOneof: { oneofKind: 'type', type: ContactType.WORK }
-    }
-  ],
-  maxNumberOfAdultOccupantsOneof: {
-    oneofKind: 'maxNumberOfAdultOccupants',
-    maxNumberOfAdultOccupants: 2
-  },
-  maxNumberOfChildOccupantsOneof: {
-    oneofKind: 'maxNumberOfChildOccupants',
-    maxNumberOfChildOccupants: 2
-  },
-  maxNumberOfOccupantsOneof: {
-    oneofKind: 'maxNumberOfOccupants',
-    maxNumberOfOccupants: 2
-  },
-  privateHomeOneof: { oneofKind: 'privateHome', privateHome: false },
-  suiteOneof: { oneofKind: 'suite', suite: false },
-  tierOneof: { oneofKind: 'tier', tier: SpaceTier.DEFAULT_STANDARD },
-  views: {
-    viewOfValleyOneof: { oneofKind: 'viewOfValley', viewOfValley: true },
-    viewOfBeachOneof: { oneofKind: 'viewOfBeach', viewOfBeach: false },
-    viewOfCityOneof: { oneofKind: 'viewOfCity', viewOfCity: false },
-    viewOfGardenOneof: { oneofKind: 'viewOfGarden', viewOfGarden: false },
-    viewOfLakeOneof: { oneofKind: 'viewOfLake', viewOfLake: false },
-    viewOfLandmarkOneof: { oneofKind: 'viewOfLandmark', viewOfLandmark: false },
-    viewOfOceanOneof: { oneofKind: 'viewOfOcean', viewOfOcean: false },
-    viewOfPoolOneof: { oneofKind: 'viewOfPool', viewOfPool: false }
-  },
-  totalLivingAreas: {
-    sleeping: {
-      numberOfBedsOneof: { oneofKind: 'numberOfBeds', numberOfBeds: 1 },
-      kingBedsOneof: { oneofKind: 'kingBeds', kingBeds: 1 },
-      queenBedsOneof: {
-        oneofKind: 'queenBedsException',
-        queenBedsException: Exception.UNSPECIFIED_REASON
-      },
-      doubleBedsOneof: {
-        oneofKind: 'doubleBedsException',
-        doubleBedsException: Exception.UNSPECIFIED_REASON
-      },
-      singleOrTwinBedsOneof: {
-        oneofKind: 'singleOrTwinBedsException',
-        singleOrTwinBedsException: Exception.UNSPECIFIED_REASON
-      },
-      bunkBedsOneof: {
-        oneofKind: 'bunkBedsException',
-        bunkBedsException: Exception.UNSPECIFIED_REASON
-      },
-      sofaBedsOneof: {
-        oneofKind: 'sofaBedsException',
-        sofaBedsException: Exception.UNSPECIFIED_REASON
-      },
-      otherBedsOneof: { oneofKind: 'otherBeds', otherBeds: 0 },
-      cribsOneof: { oneofKind: 'cribs', cribs: false },
-      cribsAvailableOneof: {
-        oneofKind: 'cribsAvailableException',
-        cribsAvailableException: Exception.UNSPECIFIED_REASON
-      },
-      cribCountOneof: {
-        oneofKind: 'cribCountException',
-        cribCountException: Exception.UNSPECIFIED_REASON
-      },
-      rollAwayBedsOneof: { oneofKind: 'rollAwayBeds', rollAwayBeds: false },
-      rollAwayBedsAvailableOneof: {
-        oneofKind: 'rollAwayBedsAvailableException',
-        rollAwayBedsAvailableException: Exception.UNSPECIFIED_REASON
-      },
-      rollAwayBedCountOneof: {
-        oneofKind: 'rollAwayBedCountException',
-        rollAwayBedCountException: Exception.UNSPECIFIED_REASON
+export const space: Item = {
+  name: 'Mountain view room',
+  description: 'Panoramic views of Ushba',
+  photos: [],
+  type: ItemType.SPACE,
+  payload: Space.toBinary({
+    uris: [
+      {
+        uri: 'https://wonderland.somewhere/',
+        typeOneof: { oneofKind: 'type', type: ContactType.WORK }
       }
+    ],
+    maxNumberOfAdultOccupantsOneof: {
+      oneofKind: 'maxNumberOfAdultOccupants',
+      maxNumberOfAdultOccupants: 2
     },
-    features: {
-      inSpaceWifiAvailableOneof: {
-        oneofKind: 'inSpaceWifiAvailable',
-        inSpaceWifiAvailable: true
+    maxNumberOfChildOccupantsOneof: {
+      oneofKind: 'maxNumberOfChildOccupants',
+      maxNumberOfChildOccupants: 2
+    },
+    maxNumberOfOccupantsOneof: {
+      oneofKind: 'maxNumberOfOccupants',
+      maxNumberOfOccupants: 2
+    },
+    privateHomeOneof: { oneofKind: 'privateHome', privateHome: false },
+    suiteOneof: { oneofKind: 'suite', suite: false },
+    tierOneof: { oneofKind: 'tier', tier: SpaceTier.DEFAULT_STANDARD },
+    views: {
+      viewOfValleyOneof: { oneofKind: 'viewOfValley', viewOfValley: true },
+      viewOfBeachOneof: { oneofKind: 'viewOfBeach', viewOfBeach: false },
+      viewOfCityOneof: { oneofKind: 'viewOfCity', viewOfCity: false },
+      viewOfGardenOneof: { oneofKind: 'viewOfGarden', viewOfGarden: false },
+      viewOfLakeOneof: { oneofKind: 'viewOfLake', viewOfLake: false },
+      viewOfLandmarkOneof: {
+        oneofKind: 'viewOfLandmark',
+        viewOfLandmark: false
+      },
+      viewOfOceanOneof: { oneofKind: 'viewOfOcean', viewOfOcean: false },
+      viewOfPoolOneof: { oneofKind: 'viewOfPool', viewOfPool: false }
+    },
+    totalLivingAreas: {
+      sleeping: {
+        numberOfBedsOneof: { oneofKind: 'numberOfBeds', numberOfBeds: 1 },
+        kingBedsOneof: { oneofKind: 'kingBeds', kingBeds: 1 },
+        queenBedsOneof: {
+          oneofKind: 'queenBedsException',
+          queenBedsException: Exception.UNSPECIFIED_REASON
+        },
+        doubleBedsOneof: {
+          oneofKind: 'doubleBedsException',
+          doubleBedsException: Exception.UNSPECIFIED_REASON
+        },
+        singleOrTwinBedsOneof: {
+          oneofKind: 'singleOrTwinBedsException',
+          singleOrTwinBedsException: Exception.UNSPECIFIED_REASON
+        },
+        bunkBedsOneof: {
+          oneofKind: 'bunkBedsException',
+          bunkBedsException: Exception.UNSPECIFIED_REASON
+        },
+        sofaBedsOneof: {
+          oneofKind: 'sofaBedsException',
+          sofaBedsException: Exception.UNSPECIFIED_REASON
+        },
+        otherBedsOneof: { oneofKind: 'otherBeds', otherBeds: 0 },
+        cribsOneof: { oneofKind: 'cribs', cribs: false },
+        cribsAvailableOneof: {
+          oneofKind: 'cribsAvailableException',
+          cribsAvailableException: Exception.UNSPECIFIED_REASON
+        },
+        cribCountOneof: {
+          oneofKind: 'cribCountException',
+          cribCountException: Exception.UNSPECIFIED_REASON
+        },
+        rollAwayBedsOneof: { oneofKind: 'rollAwayBeds', rollAwayBeds: false },
+        rollAwayBedsAvailableOneof: {
+          oneofKind: 'rollAwayBedsAvailableException',
+          rollAwayBedsAvailableException: Exception.UNSPECIFIED_REASON
+        },
+        rollAwayBedCountOneof: {
+          oneofKind: 'rollAwayBedCountException',
+          rollAwayBedCountException: Exception.UNSPECIFIED_REASON
+        }
+      },
+      features: {
+        inSpaceWifiAvailableOneof: {
+          oneofKind: 'inSpaceWifiAvailable',
+          inSpaceWifiAvailable: true
+        }
       }
     }
-  }
+  })
 };

--- a/test/quote.spec.ts
+++ b/test/quote.spec.ts
@@ -10,10 +10,10 @@ import {
   LOSRateModifier,
   OccupancyRateModifier
 } from '../src/proto/lpms';
-import { SpaceRateRepository } from '../src/repositories/ItemRateRepository';
+import { ItemRateRepository } from '../src/repositories/ItemRateRepository';
 import {
   FacilityModifierRepository,
-  SpaceModifierRepository
+  ItemModifierRepository
 } from '../src/repositories/ModifierRepository';
 
 import quoteService, {
@@ -138,13 +138,13 @@ describe('QuoteService', () => {
 
   before(async () => {
     repos = {
-      rates: new SpaceRateRepository(facilityId, spaceId),
-      modifiers: new SpaceModifierRepository(facilityId, spaceId),
+      rates: new ItemRateRepository(facilityId, spaceId),
+      modifiers: new ItemModifierRepository(facilityId, spaceId),
       facilityModifiers: new FacilityModifierRepository(facilityId)
     };
     reposClear = {
-      rates: new SpaceRateRepository(facilityId + '1', spaceId + '1'),
-      modifiers: new SpaceModifierRepository(facilityId + '1', spaceId + '1'),
+      rates: new ItemRateRepository(facilityId + '1', spaceId + '1'),
+      modifiers: new ItemModifierRepository(facilityId + '1', spaceId + '1'),
       facilityModifiers: new FacilityModifierRepository(facilityId + '1')
     };
     await repos.rates.setRateDefault(normalRate);

--- a/test/repository.spec.ts
+++ b/test/repository.spec.ts
@@ -1,16 +1,16 @@
 import {
   FacilityRuleRepository,
-  SpaceRuleRepository
+  ItemRuleRepository
 } from '../src/repositories/RuleRepository';
 import { NoticeRequiredRule, Rates } from '../src/proto/lpms';
 import { expect } from 'chai';
-import { SpaceRateRepository } from '../src/repositories/ItemRateRepository';
+import { ItemRateRepository } from '../src/repositories/ItemRateRepository';
 
 describe('facility repository rule test', async () => {
   const facilityId = '0x1234567890';
   const spaceId = '0x1234567890';
   const facilityRuleRepository = new FacilityRuleRepository(facilityId);
-  const spaceRuleRepository = new SpaceRuleRepository(facilityId, spaceId);
+  const spaceRuleRepository = new ItemRuleRepository(facilityId, spaceId);
 
   it('set rule', async () => {
     const rule: NoticeRequiredRule = {
@@ -50,7 +50,7 @@ describe('facility repository rule test', async () => {
 describe('repository rate test', async () => {
   const facilityId = '0x1234567890';
   const spaceId = '0x1234567890';
-  const spaceRuleRepository = new SpaceRateRepository(facilityId, spaceId);
+  const spaceRuleRepository = new ItemRateRepository(facilityId, spaceId);
 
   it('set rate', async () => {
     const rate: Rates = {

--- a/test/spaceSearch.spec.ts
+++ b/test/spaceSearch.spec.ts
@@ -1,6 +1,6 @@
 import {
   FacilityRuleRepository,
-  SpaceRuleRepository
+  ItemRuleRepository
 } from '../src/repositories/RuleRepository';
 import { FacilityRepository } from '../src/repositories/FacilityRepository';
 import { SpaceAvailabilityRepository } from '../src/repositories/SpaceAvailabilityRepository';
@@ -13,6 +13,7 @@ import { DayOfWeekLOSRule } from '../src/proto/lpms';
 import { FormattedDate } from '../src/services/DBService';
 import { convertDaysToSeconds } from '../src/utils';
 import { facility, space } from './common';
+import { Space } from '../src/proto/facility';
 
 describe('search service test', async () => {
   const facilityId =
@@ -23,7 +24,7 @@ describe('search service test', async () => {
     '0x1234567890123456789012345678901234567890123456789012345678901244';
   const facilityRepo = new FacilityRepository();
   const facilityRuleRepository = new FacilityRuleRepository(facilityId);
-  const spaceRuleRepository = new SpaceRuleRepository(facilityId, spaceId);
+  const spaceRuleRepository = new ItemRuleRepository(facilityId, spaceId);
   const spaceAvailabilityRepository = new SpaceAvailabilityRepository(
     facilityId,
     spaceId
@@ -43,25 +44,29 @@ describe('search service test', async () => {
     await facilityRepo.addToIndex(facilityId, 'spaces', spaceId);
     await facilityRepo.setItemKey(
       facilityId,
-      'spaces',
+      'items',
       spaceId,
       'metadata',
       space
     );
 
-    space.maxNumberOfAdultOccupantsOneof = {
+    const spaceMetadata = Space.fromBinary(space.payload as Uint8Array);
+
+    spaceMetadata.maxNumberOfAdultOccupantsOneof = {
       oneofKind: 'maxNumberOfAdultOccupants',
       maxNumberOfAdultOccupants: 1
     };
-    space.maxNumberOfChildOccupantsOneof = {
+    spaceMetadata.maxNumberOfChildOccupantsOneof = {
       oneofKind: 'maxNumberOfChildOccupants',
       maxNumberOfChildOccupants: 0
     };
 
+    space.payload = Space.toBinary(spaceMetadata);
+
     await facilityRepo.addToIndex(facilityId, 'spaces', spaceId2);
     await facilityRepo.setItemKey(
       facilityId,
-      'spaces',
+      'items',
       spaceId2,
       'metadata',
       space
@@ -228,8 +233,8 @@ describe('search service test', async () => {
     await facilityRepo.delFacilityKey(facilityId, 'metadata');
     await facilityRepo.delFromIndex(facilityId, 'spaces', spaceId);
     await facilityRepo.delFromIndex(facilityId, 'spaces', spaceId2);
-    await facilityRepo.delItemKey(facilityId, 'spaces', spaceId, 'metadata');
-    await facilityRepo.delItemKey(facilityId, 'spaces', spaceId2, 'metadata');
+    await facilityRepo.delItemKey(facilityId, 'items', spaceId, 'metadata');
+    await facilityRepo.delItemKey(facilityId, 'items', spaceId2, 'metadata');
 
     await spaceAvailabilityRepository.delAvailability('default');
     await spaceAvailabilityRepository2.delAvailability('default');


### PR DESCRIPTION
This PR:

- Removes any differential treatment at a repository level between `space` and `otherItem`. 
- The repository is responsible for maintaining the `space` index via introspection of the `Item` payload.
- Ensures that when `ServiceProviderData` is encoded, it adheres to the spec. It was found that when encoding `ServiceItemData`, incorrectly a `Space` message was being passed into the `payload` where the `payload` actually requires a `videre.stays.Item` message, and within the `videre.stays.Item` message's `payload` field should be the `Space` message for those those `Item`s that are of a `SPACE` type.