### PR TITLE
refactor: 💡 Refactored rates API

### DIFF
--- a/src/controllers/RateController.ts
+++ b/src/controllers/RateController.ts
@@ -7,18 +7,18 @@ import ApiError from '../exceptions/ApiError';
 export class RateController {
   public async getRate(req: Request, res: Response, next: NextFunction) {
     try {
-      const { facilityId, itemType, itemId, key } = req.params;
+      const { facilityId, rateType, itemId, key } = req.params;
 
       const rateRepository = new RateRepository(facilityId, itemId);
 
       const rate = await rateRepository.getRate(
         key as DefaultOrDateItemKey,
-        itemType as DBType
+        rateType as DBType
       );
 
       if (!rate) {
         throw ApiError.NotFound(
-          `rate ${key} not exist in facility ${facilityId} ${itemType} ${itemId}`
+          `rate ${key} not exist in facility ${facilityId} ${rateType} ${itemId}`
         );
       }
 
@@ -30,7 +30,7 @@ export class RateController {
 
   public async setRate(req: Request, res: Response, next: NextFunction) {
     try {
-      const { facilityId, itemType, itemId, key } = req.params;
+      const { facilityId, rateType, itemId, key } = req.params;
       const { cost } = req.body;
       const rateRepository = new RateRepository(facilityId, itemId);
 
@@ -39,12 +39,12 @@ export class RateController {
       };
 
       if (key === 'default') {
-        await rateRepository.setRateDefault(rate, itemType as DBType);
+        await rateRepository.setRateDefault(rate, rateType as DBType);
       } else {
         await rateRepository.setRate(
           key as FormattedDate,
           rate,
-          itemType as DBType
+          rateType as DBType
         );
       }
 

--- a/src/router/rates.ts
+++ b/src/router/rates.ts
@@ -4,13 +4,13 @@ import rateController from '../controllers/RateController';
 
 export default (router: Router): void => {
   router.get(
-    '/rate/:facilityId/:itemType/:itemId/:key',
+    '/rate/:facilityId/:itemId/:key/:rateType',
     authMiddleware,
     rateController.getRate
   );
 
   router.post(
-    '/rate/:facilityId/:itemType/:itemId/:key',
+    '/rate/:facilityId/:itemId/:key/:rateType',
     authMiddleware,
     rateController.setRate
   );

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -3361,7 +3361,7 @@ paths:
   #end terms
 
   #rates
-  /rate/{facilityId}/{itemType}/{itemId}/{key}:
+  /rate/{facilityId}/{itemId}/{key}/{rateType}:
     get:
       security:
         - bearerAuth: []
@@ -3375,24 +3375,24 @@ paths:
           schema:
             $ref: '#/components/schemas/Bytes32HashedId'
         - in: path
-          name: itemType
-          description: The facility id
-          required: true
-          schema:
-            type: string
-            enum: ['terms', 'items']
-        - in: path
           name: itemId
-          description: The facility id
+          description: The item id
           required: true
           schema:
             $ref: '#/components/schemas/Bytes32HashedId'
         - in: path
           name: key
-          description: The facility id
+          description: The rate key
           required: true
           schema:
             $ref: '#/components/schemas/DefaultOrDateKey'
+        - in: path
+          name: rateType
+          description: The rate type
+          required: true
+          schema:
+            type: string
+            enum: ['terms', 'items']
       responses:
         200:
           description: OK
@@ -3433,24 +3433,24 @@ paths:
           schema:
             $ref: '#/components/schemas/Bytes32HashedId'
         - in: path
-          name: itemType
-          description: The facility id
-          required: true
-          schema:
-            type: string
-            enum: ['terms', 'items']
-        - in: path
           name: itemId
-          description: The facility id
+          description: The item id
           required: true
           schema:
             $ref: '#/components/schemas/Bytes32HashedId'
         - in: path
           name: key
-          description: The facility id
+          description: The item key
           required: true
           schema:
             $ref: '#/components/schemas/DefaultOrDateKey'
+        - in: path
+          name: rateType
+          description: The rate type
+          required: true
+          schema:
+            type: string
+            enum: ['terms', 'items']
       responses:
         200:
           description: OK

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -411,7 +411,7 @@ describe('API tests', async () => {
     describe('Rates', async () => {
       it('should be throw err if rate not exist', async () => {
         await requestWithSupertest
-          .get(`/api/rate/${facilityId}/items/${spaceId}/default`)
+          .get(`/api/rate/${facilityId}/${spaceId}/default`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(404);
@@ -422,7 +422,7 @@ describe('API tests', async () => {
           cost: 100
         };
         await requestWithSupertest
-          .post(`/api/rate/${facilityId}/items/${spaceId}/default`)
+          .post(`/api/rate/${facilityId}/${spaceId}/default`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .send(rate)
@@ -431,7 +431,7 @@ describe('API tests', async () => {
 
       it('get default rate', async () => {
         const res = await requestWithSupertest
-          .get(`/api/rate/${facilityId}/items/${spaceId}/default`)
+          .get(`/api/rate/${facilityId}/${spaceId}/default`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(200);
@@ -441,7 +441,7 @@ describe('API tests', async () => {
 
       it('should throw err when key is unavailable', async () => {
         await requestWithSupertest
-          .get(`/api/rate/${facilityId}/items/${spaceId}/some-value`)
+          .get(`/api/rate/${facilityId}/${spaceId}/some-value`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(400);
@@ -452,7 +452,7 @@ describe('API tests', async () => {
           cost: 200
         };
         await requestWithSupertest
-          .post(`/api/rate/${facilityId}/items/${spaceId}/2022-01-01`)
+          .post(`/api/rate/${facilityId}/${spaceId}/2022-01-01`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .send(rate)
@@ -461,7 +461,7 @@ describe('API tests', async () => {
 
       it('get date rate', async () => {
         const res = await requestWithSupertest
-          .get(`/api/rate/${facilityId}/items/${spaceId}/2022-01-01`)
+          .get(`/api/rate/${facilityId}/${spaceId}/2022-01-01`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(200);

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -411,7 +411,7 @@ describe('API tests', async () => {
     describe('Rates', async () => {
       it('should be throw err if rate not exist', async () => {
         await requestWithSupertest
-          .get(`/api/rate/${facilityId}/${spaceId}/default`)
+          .get(`/api/rate/${facilityId}/${spaceId}/default/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(404);
@@ -422,7 +422,7 @@ describe('API tests', async () => {
           cost: 100
         };
         await requestWithSupertest
-          .post(`/api/rate/${facilityId}/${spaceId}/default`)
+          .post(`/api/rate/${facilityId}/${spaceId}/default/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .send(rate)
@@ -431,7 +431,7 @@ describe('API tests', async () => {
 
       it('get default rate', async () => {
         const res = await requestWithSupertest
-          .get(`/api/rate/${facilityId}/${spaceId}/default`)
+          .get(`/api/rate/${facilityId}/${spaceId}/default/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(200);
@@ -441,7 +441,7 @@ describe('API tests', async () => {
 
       it('should throw err when key is unavailable', async () => {
         await requestWithSupertest
-          .get(`/api/rate/${facilityId}/${spaceId}/some-value`)
+          .get(`/api/rate/${facilityId}/${spaceId}/some-value/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(400);
@@ -452,7 +452,7 @@ describe('API tests', async () => {
           cost: 200
         };
         await requestWithSupertest
-          .post(`/api/rate/${facilityId}/${spaceId}/2022-01-01`)
+          .post(`/api/rate/${facilityId}/${spaceId}/2022-01-01/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .send(rate)
@@ -461,7 +461,7 @@ describe('API tests', async () => {
 
       it('get date rate', async () => {
         const res = await requestWithSupertest
-          .get(`/api/rate/${facilityId}/${spaceId}/2022-01-01`)
+          .get(`/api/rate/${facilityId}/${spaceId}/2022-01-01/items`)
           .set('Authorization', `Bearer ${accessToken}`)
           .set('Accept', 'application/json')
           .expect(200);


### PR DESCRIPTION
The `rates` API is refactored to `/rate/{facilityId}/{itemId}/{key}/{rateType}`